### PR TITLE
Pathfinder 1.5 CSS and Layout Update

### DIFF
--- a/src/layouts/pathfinder 2e/Basic Pathfinder 2e Layout.json
+++ b/src/layouts/pathfinder 2e/Basic Pathfinder 2e Layout.json
@@ -1,0 +1,406 @@
+{
+  "blocks": [
+    {
+      "type": "inline",
+      "id": "e9b8483aeafa",
+      "properties": [],
+      "nested": [
+        {
+          "type": "property",
+          "id": "2b596a6919fb",
+          "properties": [
+            "name"
+          ],
+          "fallback": "-",
+          "markdown": true,
+          "dice": false,
+          "conditioned": true,
+          "display": " "
+        },
+        {
+          "type": "property",
+          "id": "98389a48f808",
+          "properties": [
+            "level"
+          ],
+          "fallback": "-",
+          "display": " ",
+          "conditioned": true,
+          "markdown": true,
+          "dice": false
+        }
+      ],
+      "hasRule": true
+    },
+    {
+      "type": "group",
+      "id": "4b3a6809a938",
+      "properties": [],
+      "nested": [
+        {
+          "type": "inline",
+          "id": "289a4b787968",
+          "properties": [],
+          "nested": [
+            {
+              "type": "property",
+              "id": "694a3888b859",
+              "properties": [
+                "rare_01"
+              ],
+              "fallback": "-",
+              "conditioned": true,
+              "markdown": true
+            },
+            {
+              "type": "property",
+              "id": "590a88988ae8",
+              "properties": [
+                "rare_02"
+              ],
+              "fallback": "-",
+              "conditioned": true,
+              "markdown": true
+            },
+            {
+              "type": "property",
+              "id": "9a9be808699a",
+              "properties": [
+                "rare_03"
+              ],
+              "fallback": "-",
+              "conditioned": true,
+              "markdown": true
+            },
+            {
+              "type": "property",
+              "id": "2988db1a685a",
+              "properties": [
+                "rare_04"
+              ],
+              "fallback": "-",
+              "conditioned": true,
+              "markdown": true
+            },
+            {
+              "type": "property",
+              "id": "ba891ba8cbeb",
+              "properties": [
+                "alignment"
+              ],
+              "fallback": " ",
+              "display": " ",
+              "conditioned": true,
+              "markdown": true
+            },
+            {
+              "type": "property",
+              "id": "ebf9883938a8",
+              "properties": [
+                "size"
+              ],
+              "fallback": " ",
+              "display": " ",
+              "conditioned": true,
+              "markdown": true
+            },
+            {
+              "type": "property",
+              "id": "dabaf9e9fb68",
+              "properties": [
+                "trait_01"
+              ],
+              "fallback": " ",
+              "display": " ",
+              "conditioned": true,
+              "markdown": true
+            },
+            {
+              "type": "property",
+              "id": "e81a6aeadbf9",
+              "properties": [
+                "trait_02"
+              ],
+              "fallback": " ",
+              "display": " ",
+              "conditioned": true,
+              "markdown": true
+            },
+            {
+              "type": "property",
+              "id": "fa7919caabbb",
+              "properties": [
+                "trait_03"
+              ],
+              "fallback": "-",
+              "conditioned": true,
+              "display": " ",
+              "markdown": true
+            },
+            {
+              "type": "property",
+              "id": "58c9c8580b68",
+              "properties": [
+                "trait_04"
+              ],
+              "fallback": "-",
+              "conditioned": true,
+              "display": " ",
+              "markdown": true
+            },
+            {
+              "type": "property",
+              "id": "da894a7b8849",
+              "properties": [
+                "trait_05"
+              ],
+              "fallback": "-",
+              "display": " ",
+              "conditioned": true,
+              "markdown": true
+            },
+            {
+              "type": "property",
+              "id": "fb6b4b6bab49",
+              "properties": [
+                "trait_06"
+              ],
+              "fallback": "-",
+              "display": " ",
+              "conditioned": true,
+              "markdown": true
+            },
+            {
+              "type": "property",
+              "id": "480a5bfafb88",
+              "properties": [
+                "trait_07"
+              ],
+              "fallback": "-",
+              "display": " ",
+              "conditioned": true,
+              "markdown": true
+            }
+          ],
+          "hasRule": true,
+          "conditioned": true
+        }
+      ]
+    },
+    {
+      "type": "group",
+      "id": "5999ea79ca3b",
+      "properties": [],
+      "nested": [
+        {
+          "type": "traits",
+          "id": "9a9af9fbe959",
+          "properties": [
+            "perception"
+          ],
+          "fallback": "-",
+          "heading": " ",
+          "conditioned": true,
+          "dice": true,
+          "markdown": true,
+          "headingProp": true
+        },
+        {
+          "type": "property",
+          "id": "ba28f9384918",
+          "properties": [
+            "languages"
+          ],
+          "fallback": "-",
+          "display": "Language",
+          "conditioned": true,
+          "markdown": true
+        },
+        {
+          "type": "traits",
+          "id": "a8f8187b89fb",
+          "properties": [
+            "skills"
+          ],
+          "fallback": "-",
+          "markdown": true,
+          "dice": true,
+          "conditioned": true,
+          "heading": " "
+        },
+        {
+          "type": "table",
+          "id": "b82b0a1a9969",
+          "properties": [
+            "abilityMods"
+          ],
+          "headers": [
+            "Str",
+            "Dex",
+            "Con",
+            "Int",
+            "Wis",
+            "Cha"
+          ],
+          "calculate": false,
+          "fallback": "-",
+          "conditioned": true,
+          "dice": true
+        },
+        {
+          "type": "traits",
+          "id": "e96ba9d8a80a",
+          "properties": [
+            "abilities_top"
+          ],
+          "fallback": "-",
+          "conditioned": true,
+          "dice": true,
+          "markdown": true,
+          "heading": "  ",
+          "hasRule": false
+        }
+      ],
+      "hasRule": true
+    },
+    {
+      "type": "group",
+      "id": "faaa08993a98",
+      "properties": [],
+      "nested": [
+        {
+          "type": "traits",
+          "id": "68ca69891bea",
+          "properties": [
+            "armorclass"
+          ],
+          "fallback": "-",
+          "heading": "",
+          "conditioned": true,
+          "dice": true,
+          "markdown": true
+        },
+        {
+          "type": "traits",
+          "id": "9b1998e9a8da",
+          "properties": [
+            "health"
+          ],
+          "fallback": "-",
+          "heading": "",
+          "conditioned": true,
+          "dice": true,
+          "markdown": true
+        },
+        {
+          "type": "traits",
+          "id": "ca2bf968987b",
+          "properties": [
+            "abilities_mid"
+          ],
+          "fallback": "-",
+          "heading": "",
+          "conditioned": true,
+          "dice": true,
+          "markdown": true,
+          "hasRule": false
+        }
+      ],
+      "hasRule": true
+    },
+    {
+      "type": "group",
+      "id": "cbeabaf93b58",
+      "properties": [],
+      "nested": [
+        {
+          "type": "property",
+          "id": "0b4809ba0b29",
+          "properties": [
+            "speed"
+          ],
+          "fallback": "-",
+          "display": "Speed",
+          "conditioned": true,
+          "markdown": true,
+          "dice": false
+        },
+        {
+          "type": "traits",
+          "id": "882bc9aa0898",
+          "properties": [
+            "attacks"
+          ],
+          "fallback": "-",
+          "conditioned": true,
+          "dice": true,
+          "markdown": true,
+          "headingProp": false,
+          "heading": ""
+        },
+        {
+          "type": "traits",
+          "id": "6919b8996939",
+          "properties": [
+            "spellcasting"
+          ],
+          "fallback": "-",
+          "heading": " ",
+          "markdown": true,
+          "dice": true,
+          "conditioned": true
+        },
+        {
+          "type": "traits",
+          "id": "aacb399a3b58",
+          "properties": [
+            "abilities_bot"
+          ],
+          "fallback": "-",
+          "conditioned": true,
+          "dice": true,
+          "markdown": true,
+          "hasRule": false
+        }
+      ],
+      "hasRule": true
+    },
+    {
+      "type": "text",
+      "id": "1b195a894b58",
+      "properties": [
+        "token"
+      ],
+      "text": null,
+      "fallback": "",
+      "heading": "Show to Players",
+      "conditioned": true,
+      "markdown": true
+    },
+    {
+      "type": "image",
+      "id": "1bba89582b29",
+      "properties": [
+        "token"
+      ],
+      "fallback": "",
+      "conditioned": true,
+      "hasRule": true
+    },
+    {
+      "type": "property",
+      "id": "88e97a485b79",
+      "properties": [
+        "sourcebook"
+      ],
+      "fallback": "-",
+      "conditioned": true,
+      "markdown": true,
+      "dice": false,
+      "display": " Source:"
+    }
+  ],
+  "name": "Basic Pathfinder 2e Layout",
+  "id": "path-2e-block",
+  "edited": true
+}

--- a/src/layouts/pathfinder 2e/pf2e.css
+++ b/src/layouts/pathfinder 2e/pf2e.css
@@ -1,655 +1,2657 @@
+@charset "UTF-8";
 /*!
 Pathfinder TTRPG General Statblock Layout CSS
 
-version: 1.4.0
+version: 1.5.0
 by:      Moritz Jung (https://github.com/mProjectsCode) and Sigrunixia
 repo:    https://github.com/mProjectsCode/obsidian-pathfinder2e-statblocks
 
 This file was generated from SCSS.
 Looking for `!important`? Check for Rare_0X, and Trait_0X. That is the only spots they are used in this file.
 */
+/*
+Pathfinder Glyphs Only and any associated classes to call those Glyphs
+*/
 @font-face {
-    font-family: "Pathfinder";
-    src: url(data:application/x-font-ttf;charset=utf-8;base64,AAEAAAALAIAAAwAwT1MvMg8xOUgAAAC8AAAAYGNtYXBWj1fJAAABHAAAAHRnYXNwAAAAEAAAAZAAAAAIZ2x5ZlORXq8AAAGYAAACYGhlYWQnahodAAAD+AAAADZoaGVhDDUIawAABDAAAAAkaG10eCWQAIcAAARUAAAAKGxvY2ECvAH8AAAEfAAAABZtYXhwAA8APwAABJQAAAAgbmFtZQQfBa8AAAS0AAAC63Bvc3QAAwAAAAAHoAAAACAAAwTLAZAABQAAApkCzAAAAI8CmQLMAAAB6wAzAQkAAAAAAAAAAAAAAAAAAAABAAAAIAAAAAAAAAAAAAAAAABAAAArUwPA/8AAQAPAAEAAAAABAAAAAAAAAAAAAAAgAAAAAAADAAAAAwAAABwAAQADAAAAHAADAAEAAAAcAAQAWAAAABIAEAADAAIAAQAgADArMis7Kz0rU//9//8AAAAAACAAMCsyKzorPStT//3//wAB/+P/1NTT1MzUy9S2AAMAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAH//wAPAAEAAAAAAAAAAAACAAA3OQEAAAAAAQAAAAAAAAAAAAIAADc5AQAAAAABAAAAAAAAAAAAAgAANzkBAAAAAAEAAAAAAAAAAAACAAA3OQEAAAAAAgAoACIEHwNXADcAPAAAASYnJicmJyYHBgcGBwYHBgc2NzY3Njc2NzYXFhcWFxYXFgcGBwYHBgcGBwYnFhcWNzY3Njc2NzYBBSc3AQQdFzs8VFNlZWpLQUEzMyQkERUdHSMkKSouVVFRQ0QwMBISEBEsK0RDVRwcGxs/REVFalRUNjYVFPyNAeltOP5MAkdHOTklJQ0ODwsYGCIiKyovGhYXEhINDQcMCwsdHi4uOTo3Ny0uISAMBAECAQ4DAwoPKSg5OEVE/opnldf++wAAAAMAIP/BBmADvwAFAAkADwAACQEHCQEXAQcXNyUBBxcHFwQa/gH2AQj++Pb+vLe3twTS/kDZ6OjZAcAB//f++P749wK2t7e3CAHA2Ojo2QAAAgAC/8AD/gPAAAUACQAACQEHCQEXAQcXNwP+/gD3AQn+9/f+u7e3twHAAgD3/vf+9/cCt7e3twAEAC3/wAhzA8AABQALAA8AFQAACQEHCQEXCQEHFwcXAQcXNyUBBxcHFwQp/gD3AQn+9/cGSv6Yr7u7r/nZt7e3BNz+P9rp6doBwAIA9/73/vf3AgoBaK66u64CFre3twgBwdno6dkAAAMAEP/ABBADwAAEAAkADwAACQQBNxcHJwEnNyc3AQIU/fwB/QID/gT+uG1tbW0BN3H79XwBZwPA/fr+BgIDAf3+EG1tbW3+hHH79nz+mQAAAQAAAAEZmgtZ1jpfDzz1AAsEAAAAAADf694DAAAAAN/r3gMAAP/ACHMDwAAAAAgAAgAAAAAAAAABAAADwP/AAAAIoAAAAAAIcwABAAAAAAAAAAAAAAAAAAAACgQAAAAAAAAAAAAAAAIAAAAEAAAABFAAKAaAACAEAAACCKAALQQgABAAAAAAAAoAFAAeACgAkAC4ANQBCAEwAAAAAQAAAAoAPQAEAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAABIA3gABAAAAAAABAAoAAAABAAAAAAACAAcB2gABAAAAAAADAAoBngABAAAAAAAEAAoB7wABAAAAAAAFAAsBfQABAAAAAAAGAAoBvAABAAAAAAAKADYA2wABAAAAAAANABcAHgABAAAAAAAOACgAYwADAAEECQABABQACgADAAEECQACAA4B4QADAAEECQADABQBqAADAAEECQAEABQB+QADAAEECQAFABYBiAADAAEECQAGABQBxgADAAEECQAKAGwBEQADAAEECQANAC4ANQADAAEECQAOAFAAi1BhdGhmaW5kZXIAUABhAHQAaABmAGkAbgBkAGUAclBhaXpvIENvbW11bml0eSBMaWNlbnNlAFAAYQBpAHoAbwAgAEMAbwBtAG0AdQBuAGkAdAB5ACAATABpAGMAZQBuAHMAZWh0dHBzOi8vcGFpem8uY29tL2NvbW11bml0eS9jb21tdW5pdHl1c2UAaAB0AHQAcABzADoALwAvAHAAYQBpAHoAbwAuAGMAbwBtAC8AYwBvAG0AbQB1AG4AaQB0AHkALwBjAG8AbQBtAHUAbgBpAHQAeQB1AHMAZVBhdGhmaW5kZXIgMmUgQWN0aW9uIEdseXBocwpGb250IGdlbmVyYXRlZCBieSBJY29Nb29uLgBQAGEAdABoAGYAaQBuAGQAZQByACAAMgBlACAAQQBjAHQAaQBvAG4AIABHAGwAeQBwAGgAcwAKAEYAbwBuAHQAIABnAGUAbgBlAHIAYQB0AGUAZAAgAGIAeQAgAEkAYwBvAE0AbwBvAG4ALlZlcnNpb24gMS4xAFYAZQByAHMAaQBvAG4AIAAxAC4AMVBhdGhmaW5kZXIAUABhAHQAaABmAGkAbgBkAGUAclBhdGhmaW5kZXIAUABhAHQAaABmAGkAbgBkAGUAclJlZ3VsYXIAUgBlAGcAdQBsAGEAclBhdGhmaW5kZXIAUABhAHQAaABmAGkAbgBkAGUAcgAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==)
-        format("truetype");
-    font-weight: normal;
-    font-style: normal;
-    font-display: block;
+  font-family: "Pathfinder";
+  src: url("data:application/x-font-ttf;charset=utf-8;base64,AAEAAAALAIAAAwAwT1MvMg8xOUgAAAC8AAAAYGNtYXBWj1fJAAABHAAAAHRnYXNwAAAAEAAAAZAAAAAIZ2x5ZlORXq8AAAGYAAACYGhlYWQnahodAAAD+AAAADZoaGVhDDUIawAABDAAAAAkaG10eCWQAIcAAARUAAAAKGxvY2ECvAH8AAAEfAAAABZtYXhwAA8APwAABJQAAAAgbmFtZQQfBa8AAAS0AAAC63Bvc3QAAwAAAAAHoAAAACAAAwTLAZAABQAAApkCzAAAAI8CmQLMAAAB6wAzAQkAAAAAAAAAAAAAAAAAAAABAAAAIAAAAAAAAAAAAAAAAABAAAArUwPA/8AAQAPAAEAAAAABAAAAAAAAAAAAAAAgAAAAAAADAAAAAwAAABwAAQADAAAAHAADAAEAAAAcAAQAWAAAABIAEAADAAIAAQAgADArMis7Kz0rU//9//8AAAAAACAAMCsyKzorPStT//3//wAB/+P/1NTT1MzUy9S2AAMAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAH//wAPAAEAAAAAAAAAAAACAAA3OQEAAAAAAQAAAAAAAAAAAAIAADc5AQAAAAABAAAAAAAAAAAAAgAANzkBAAAAAAEAAAAAAAAAAAACAAA3OQEAAAAAAgAoACIEHwNXADcAPAAAASYnJicmJyYHBgcGBwYHBgc2NzY3Njc2NzYXFhcWFxYXFgcGBwYHBgcGBwYnFhcWNzY3Njc2NzYBBSc3AQQdFzs8VFNlZWpLQUEzMyQkERUdHSMkKSouVVFRQ0QwMBISEBEsK0RDVRwcGxs/REVFalRUNjYVFPyNAeltOP5MAkdHOTklJQ0ODwsYGCIiKyovGhYXEhINDQcMCwsdHi4uOTo3Ny0uISAMBAECAQ4DAwoPKSg5OEVE/opnldf++wAAAAMAIP/BBmADvwAFAAkADwAACQEHCQEXAQcXNyUBBxcHFwQa/gH2AQj++Pb+vLe3twTS/kDZ6OjZAcAB//f++P749wK2t7e3CAHA2Ojo2QAAAgAC/8AD/gPAAAUACQAACQEHCQEXAQcXNwP+/gD3AQn+9/f+u7e3twHAAgD3/vf+9/cCt7e3twAEAC3/wAhzA8AABQALAA8AFQAACQEHCQEXCQEHFwcXAQcXNyUBBxcHFwQp/gD3AQn+9/cGSv6Yr7u7r/nZt7e3BNz+P9rp6doBwAIA9/73/vf3AgoBaK66u64CFre3twgBwdno6dkAAAMAEP/ABBADwAAEAAkADwAACQQBNxcHJwEnNyc3AQIU/fwB/QID/gT+uG1tbW0BN3H79XwBZwPA/fr+BgIDAf3+EG1tbW3+hHH79nz+mQAAAQAAAAEZmgtZ1jpfDzz1AAsEAAAAAADf694DAAAAAN/r3gMAAP/ACHMDwAAAAAgAAgAAAAAAAAABAAADwP/AAAAIoAAAAAAIcwABAAAAAAAAAAAAAAAAAAAACgQAAAAAAAAAAAAAAAIAAAAEAAAABFAAKAaAACAEAAACCKAALQQgABAAAAAAAAoAFAAeACgAkAC4ANQBCAEwAAAAAQAAAAoAPQAEAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAABIA3gABAAAAAAABAAoAAAABAAAAAAACAAcB2gABAAAAAAADAAoBngABAAAAAAAEAAoB7wABAAAAAAAFAAsBfQABAAAAAAAGAAoBvAABAAAAAAAKADYA2wABAAAAAAANABcAHgABAAAAAAAOACgAYwADAAEECQABABQACgADAAEECQACAA4B4QADAAEECQADABQBqAADAAEECQAEABQB+QADAAEECQAFABYBiAADAAEECQAGABQBxgADAAEECQAKAGwBEQADAAEECQANAC4ANQADAAEECQAOAFAAi1BhdGhmaW5kZXIAUABhAHQAaABmAGkAbgBkAGUAclBhaXpvIENvbW11bml0eSBMaWNlbnNlAFAAYQBpAHoAbwAgAEMAbwBtAG0AdQBuAGkAdAB5ACAATABpAGMAZQBuAHMAZWh0dHBzOi8vcGFpem8uY29tL2NvbW11bml0eS9jb21tdW5pdHl1c2UAaAB0AHQAcABzADoALwAvAHAAYQBpAHoAbwAuAGMAbwBtAC8AYwBvAG0AbQB1AG4AaQB0AHkALwBjAG8AbQBtAHUAbgBpAHQAeQB1AHMAZVBhdGhmaW5kZXIgMmUgQWN0aW9uIEdseXBocwpGb250IGdlbmVyYXRlZCBieSBJY29Nb29uLgBQAGEAdABoAGYAaQBuAGQAZQByACAAMgBlACAAQQBjAHQAaQBvAG4AIABHAGwAeQBwAGgAcwAKAEYAbwBuAHQAIABnAGUAbgBlAHIAYQB0AGUAZAAgAGIAeQAgAEkAYwBvAE0AbwBvAG4ALlZlcnNpb24gMS4xAFYAZQByAHMAaQBvAG4AIAAxAC4AMVBhdGhmaW5kZXIAUABhAHQAaABmAGkAbgBkAGUAclBhdGhmaW5kZXIAUABhAHQAaABmAGkAbgBkAGUAclJlZ3VsYXIAUgBlAGcAdQBsAGEAclBhdGhmaW5kZXIAUABhAHQAaABmAGkAbgBkAGUAcgAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==") format("truetype");
+  font-weight: normal;
+  font-style: normal;
+  font-display: block;
 }
-[class^="glyph-"],
+[class^=glyph-],
 [class*=" glyph-"] {
-    font-family: "Pathfinder" !important;
-    font-style: normal;
-    font-weight: normal;
-    font-variant: normal;
-    text-transform: none;
-    line-height: 1;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
+  /* use !important to prevent issues with browser extensions that change fonts */
+  font-family: "Pathfinder", serif !important;
+  font-style: normal;
+  font-weight: normal;
+  font-variant: normal;
+  text-transform: none;
+  line-height: 1;
+  /* Better Font Rendering =========== */
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
+
 .glyph-1action:before {
-    content: "\2b3b";
+  content: "⬻";
 }
+
 .glyph-2actions:before {
-    content: "\2b3a";
+  content: "⬺";
 }
+
 .glyph-3actions:before {
-    content: "\2b3d";
+  content: "⬽";
 }
-.glyph-delay:before {
-    content: "\2b53";
+
+.glyph-free:before {
+  content: "⭓";
 }
+
 .glyph-reaction:before {
-    content: "\2b32";
+  content: "⬲";
 }
+
 /*!
 /* @settings
-name: Pathfinder Statblocks
-id: path2eblock
+name: Pathfinder 2e Statblocks
+id: pathfinder-2e-statblocks
 collapsed: true
 settings:
   -
-    id: statblock-theme-creature
+    id: layout-theme-basic
     title: Creature Statblock Theme
     description: The theme of the creature statblock
     type: class-select
     allowEmpty: false
-    default: path2eblock-theme-default
+    default: basic-pathfinder-2e-layout-theme-default
     options:
     -
         label: Default
-        value: path2eblock-theme-default
+        value: basic-pathfinder-2e-layout-theme-default
     -
         label: Kingmaker
-        value: path2eblock-theme-kingmaker
+        value: basic-pathfinder-2e-layout-theme-kingmaker
   -
-    id: statblock-theme-action
+    id: layout-theme-action
     title: Action Statblock Theme
     description: The theme of the action statblock
     type: class-select
     allowEmpty: false
-    default: path2eblockact-theme-default
+    default: pathfinder-2e-action-layout-theme-default
     options:
     -
         label: Default
-        value: path2eblockact-theme-default
+        value: pathfinder-2e-action-layout-theme-default
     -
         label: Kingmaker
-        value: path2eblockact-theme-kingmaker
+        value: pathfinder-2e-action-layout-theme-kingmaker
   -
-    id: statblock-theme-hazard
+    id: layout-theme-hazard
     title: Hazard Statblock Theme
     description: The theme of the hazard statblock
     type: class-select
     allowEmpty: false
-    default: path2eblockhaz-theme-default
+    default: pathfinder-2e-hazard-layout-theme-default
     options:
     -
         label: Default
-        value: path2eblockhaz-theme-default
+        value: pathfinder-2e-hazard-layout-theme-default
     -
         label: Kingmaker
-        value: path2eblockhaz-theme-kingmaker
+        value: pathfinder-2e-hazard-layout-theme-kingmaker
   -
-    id: statblock-theme-influence
+    id: layout-theme-influence
     title: Influence Statblock Theme
     description: The theme of the influence subsystem statblock
     type: class-select
     allowEmpty: false
-    default: path2eblockinf-theme-default
+    default: pathfinder-2e-influence-layout-theme-default
     options:
     -
         label: Default
-        value: path2eblockinf-theme-default
+        value: pathfinder-2e-influence-layout-theme-default
     -
         label: Kingmaker
-        value: path2eblockinf-theme-kingmaker
+        value: pathfinder-2e-influence-layout-theme-kingmaker
   -
-    id: statblock-theme-misc
+    id: layout-theme-misc
     title: Misc Statblock Theme
     description: The theme of the misc statblock
     type: class-select
     allowEmpty: false
-    default: path2eblockmisc-theme-default
+    default: pathfinder-2e-misc-layout-theme-default
     options:
     -
         label: Default
-        value: path2eblockmisc-theme-default
+        value: pathfinder-2e-misc-layout-theme-default
     -
         label: Kingmaker
-        value: path2eblockmisc-theme-kingmaker
+        value: pathfinder-2e-misc-layout-theme-kingmaker
   -
-    id: statblock-theme-quest
+    id: layout-theme-quest
     title: Quest Statblock Theme
     description: The theme of the quest statblock
     type: class-select
     allowEmpty: false
-    default: path2eblockquest-theme-default
+    default: pathfinder-2e-quest-layout-theme-default
     options:
     -
         label: Default
-        value: path2eblockquest-theme-default
+        value: pathfinder-2e-quest-layout-theme-default
     -
         label: Kingmaker
-        value: path2eblockquest-theme-kingmaker
+        value: pathfinder-2e-quest-layout-theme-kingmaker
   -
-    id: statblock-theme-set
+    id: layout-theme-settlement
     title: Settlement Statblock Theme
     description: The theme of the settlement statblock
     type: class-select
     allowEmpty: false
-    default: path2eblockset-theme-default
+    default: pathfinder-2e-settlement-layout-theme-default
     options:
     -
         label: Default
-        value: path2eblockset-theme-default
+        value: pathfinder-2e-settlement-layout-theme-default
     -
         label: Kingmaker
-        value: path2eblockset-theme-kingmaker
+        value: pathfinder-2e-settlement-layout-theme-kingmaker
  */
-body.path2eblock-theme-default .statblock.basic-pathfinder-2e-layout {
-    --statblock-color-common: rgb(54, 69, 79);
-    --statblock-color-uncommon: rgb(143, 85, 66);
-    --statblock-color-rare: rgb(11, 37, 96);
-    --statblock-color-unique: rgb(77, 27, 106);
-    --statblock-color-alignment: rgb(89, 98, 143);
-    --statblock-color-size: rgb(75, 122, 92);
-    --statblock-color-trait: rgb(86, 12, 6);
+body.basic-pathfinder-2e-layout-theme-default .statblock.basic-pathfinder-2e-layout {
+  --statblock-color-common: rgb(54, 69, 79);
+  --statblock-color-uncommon: rgb(143, 85, 66);
+  --statblock-color-rare: rgb(11, 37, 96);
+  --statblock-color-unique: rgb(77, 27, 106);
+  --statblock-color-alignment: rgb(89, 98, 143);
+  --statblock-color-size: rgb(75, 122, 92);
+  --statblock-color-trait: rgb(86, 12, 6);
 }
-body.path2eblockact-theme-default .statblock.basic-pathfinder-2e-layoutact {
-    --statblock-color-common: rgb(54, 69, 79);
-    --statblock-color-uncommon: rgb(143, 85, 66);
-    --statblock-color-rare: rgb(11, 37, 96);
-    --statblock-color-unique: rgb(77, 27, 106);
-    --statblock-color-alignment: rgb(89, 98, 143);
-    --statblock-color-size: rgb(75, 122, 92);
-    --statblock-color-trait: rgb(86, 12, 6);
+
+body.pathfinder-2e-action-layout-theme-default .statblock.pathfinder-2e-action-layout {
+  --statblock-color-common: rgb(54, 69, 79);
+  --statblock-color-uncommon: rgb(143, 85, 66);
+  --statblock-color-rare: rgb(11, 37, 96);
+  --statblock-color-unique: rgb(77, 27, 106);
+  --statblock-color-alignment: rgb(89, 98, 143);
+  --statblock-color-size: rgb(75, 122, 92);
+  --statblock-color-trait: rgb(86, 12, 6);
 }
-body.path2eblockhaz-theme-default .statblock.basic-pathfinder-2e-layouthaz {
-    --statblock-color-common: rgb(54, 69, 79);
-    --statblock-color-uncommon: rgb(143, 85, 66);
-    --statblock-color-rare: rgb(11, 37, 96);
-    --statblock-color-unique: rgb(77, 27, 106);
-    --statblock-color-alignment: rgb(89, 98, 143);
-    --statblock-color-size: rgb(75, 122, 92);
-    --statblock-color-trait: rgb(86, 12, 6);
+
+body.pathfinder-2e-hazard-layout-theme-default .statblock.pathfinder-2e-hazard-layout {
+  --statblock-color-common: rgb(54, 69, 79);
+  --statblock-color-uncommon: rgb(143, 85, 66);
+  --statblock-color-rare: rgb(11, 37, 96);
+  --statblock-color-unique: rgb(77, 27, 106);
+  --statblock-color-alignment: rgb(89, 98, 143);
+  --statblock-color-size: rgb(75, 122, 92);
+  --statblock-color-trait: rgb(86, 12, 6);
 }
-body.path2eblockinf-theme-default .statblock.basic-pathfinder-2e-layoutinf {
-    --statblock-color-common: rgb(54, 69, 79);
-    --statblock-color-uncommon: rgb(143, 85, 66);
-    --statblock-color-rare: rgb(11, 37, 96);
-    --statblock-color-unique: rgb(77, 27, 106);
-    --statblock-color-alignment: rgb(89, 98, 143);
-    --statblock-color-size: rgb(75, 122, 92);
-    --statblock-color-trait: rgb(86, 12, 6);
+
+body.pathfinder-2e-influence-layout-theme-default .statblock.pathfinder-2e-influence-layout {
+  --statblock-color-common: rgb(54, 69, 79);
+  --statblock-color-uncommon: rgb(143, 85, 66);
+  --statblock-color-rare: rgb(11, 37, 96);
+  --statblock-color-unique: rgb(77, 27, 106);
+  --statblock-color-alignment: rgb(89, 98, 143);
+  --statblock-color-size: rgb(75, 122, 92);
+  --statblock-color-trait: rgb(86, 12, 6);
 }
-body.path2eblockmisc-theme-default .statblock.basic-pathfinder-2e-layoutmisc {
-    --statblock-color-common: rgb(54, 69, 79);
-    --statblock-color-uncommon: rgb(143, 85, 66);
-    --statblock-color-rare: rgb(11, 37, 96);
-    --statblock-color-unique: rgb(77, 27, 106);
-    --statblock-color-alignment: rgb(89, 98, 143);
-    --statblock-color-size: rgb(75, 122, 92);
-    --statblock-color-trait: rgb(86, 12, 6);
+
+body.pathfinder-2e-misc-layout-theme-default .statblock.pathfinder-2e-misc-layout {
+  --statblock-color-common: rgb(54, 69, 79);
+  --statblock-color-uncommon: rgb(143, 85, 66);
+  --statblock-color-rare: rgb(11, 37, 96);
+  --statblock-color-unique: rgb(77, 27, 106);
+  --statblock-color-alignment: rgb(89, 98, 143);
+  --statblock-color-size: rgb(75, 122, 92);
+  --statblock-color-trait: rgb(86, 12, 6);
 }
-body.path2eblockquest-theme-default .statblock.basic-pathfinder-2e-layoutquest {
-    --statblock-color-common: rgb(54, 69, 79);
-    --statblock-color-uncommon: rgb(143, 85, 66);
-    --statblock-color-rare: rgb(11, 37, 96);
-    --statblock-color-unique: rgb(77, 27, 106);
-    --statblock-color-alignment: rgb(89, 98, 143);
-    --statblock-color-size: rgb(75, 122, 92);
-    --statblock-color-trait: rgb(86, 12, 6);
+
+body.pathfinder-2e-quest-layout-theme-default .statblock.pathfinder-2e-quest-layout {
+  --statblock-color-common: rgb(54, 69, 79);
+  --statblock-color-uncommon: rgb(143, 85, 66);
+  --statblock-color-rare: rgb(11, 37, 96);
+  --statblock-color-unique: rgb(77, 27, 106);
+  --statblock-color-alignment: rgb(89, 98, 143);
+  --statblock-color-size: rgb(75, 122, 92);
+  --statblock-color-trait: rgb(86, 12, 6);
 }
-body.path2eblockset-theme-default .statblock.basic-pathfinder-2e-layoutset {
-    --statblock-color-common: rgb(54, 69, 79);
-    --statblock-color-uncommon: rgb(143, 85, 66);
-    --statblock-color-rare: rgb(11, 37, 96);
-    --statblock-color-unique: rgb(77, 27, 106);
-    --statblock-color-alignment: rgb(89, 98, 143);
-    --statblock-color-size: rgb(75, 122, 92);
-    --statblock-color-trait: rgb(86, 12, 6);
+
+body.pathfinder-2e-settlement-layout-theme-default .statblock.pathfinder-2e-settlement-layout {
+  --statblock-color-common: rgb(54, 69, 79);
+  --statblock-color-uncommon: rgb(143, 85, 66);
+  --statblock-color-rare: rgb(11, 37, 96);
+  --statblock-color-unique: rgb(77, 27, 106);
+  --statblock-color-alignment: rgb(89, 98, 143);
+  --statblock-color-size: rgb(75, 122, 92);
+  --statblock-color-trait: rgb(86, 12, 6);
 }
-body.path2eblock-theme-kingmaker .statblock.basic-pathfinder-2e-layout {
-    --statblock-color-common: rgb(54, 69, 79);
-    --statblock-color-uncommon: rgb(143, 85, 66);
-    --statblock-color-rare: rgb(11, 37, 96);
-    --statblock-color-unique: rgb(77, 27, 106);
-    --statblock-color-alignment: rgb(97, 129, 157);
-    --statblock-color-size: rgb(25, 66, 26);
-    --statblock-color-trait: rgb(125, 143, 63);
+
+body.basic-pathfinder-2e-layout-theme-kingmaker .statblock.basic-pathfinder-2e-layout {
+  --statblock-color-common: rgb(54, 69, 79);
+  --statblock-color-uncommon: rgb(143, 85, 66);
+  --statblock-color-rare: rgb(11, 37, 96);
+  --statblock-color-unique: rgb(77, 27, 106);
+  --statblock-color-alignment: rgb(97, 129, 157);
+  --statblock-color-size: rgb(25, 66, 26);
+  --statblock-color-trait: rgb(125, 143, 63);
 }
-body.path2eblockact-theme-kingmaker .statblock.basic-pathfinder-2e-layoutact {
-    --statblock-color-common: rgb(54, 69, 79);
-    --statblock-color-uncommon: rgb(143, 85, 66);
-    --statblock-color-rare: rgb(11, 37, 96);
-    --statblock-color-unique: rgb(77, 27, 106);
-    --statblock-color-alignment: rgb(97, 129, 157);
-    --statblock-color-size: rgb(25, 66, 26);
-    --statblock-color-trait: rgb(125, 143, 63);
+
+body.pathfinder-2e-action-layout-theme-kingmaker .statblock.pathfinder-2e-action-layout {
+  --statblock-color-common: rgb(54, 69, 79);
+  --statblock-color-uncommon: rgb(143, 85, 66);
+  --statblock-color-rare: rgb(11, 37, 96);
+  --statblock-color-unique: rgb(77, 27, 106);
+  --statblock-color-alignment: rgb(97, 129, 157);
+  --statblock-color-size: rgb(25, 66, 26);
+  --statblock-color-trait: rgb(125, 143, 63);
 }
-body.path2eblockhaz-theme-kingmaker .statblock.basic-pathfinder-2e-layouthaz {
-    --statblock-color-common: rgb(54, 69, 79);
-    --statblock-color-uncommon: rgb(143, 85, 66);
-    --statblock-color-rare: rgb(11, 37, 96);
-    --statblock-color-unique: rgb(77, 27, 106);
-    --statblock-color-alignment: rgb(97, 129, 157);
-    --statblock-color-size: rgb(25, 66, 26);
-    --statblock-color-trait: rgb(125, 143, 63);
+
+body.pathfinder-2e-hazard-layout-theme-kingmaker .statblock.pathfinder-2e-hazard-layout {
+  --statblock-color-common: rgb(54, 69, 79);
+  --statblock-color-uncommon: rgb(143, 85, 66);
+  --statblock-color-rare: rgb(11, 37, 96);
+  --statblock-color-unique: rgb(77, 27, 106);
+  --statblock-color-alignment: rgb(97, 129, 157);
+  --statblock-color-size: rgb(25, 66, 26);
+  --statblock-color-trait: rgb(125, 143, 63);
 }
-body.path2eblockinf-theme-kingmaker .statblock.basic-pathfinder-2e-layoutinf {
-    --statblock-color-common: rgb(54, 69, 79);
-    --statblock-color-uncommon: rgb(143, 85, 66);
-    --statblock-color-rare: rgb(11, 37, 96);
-    --statblock-color-unique: rgb(77, 27, 106);
-    --statblock-color-alignment: rgb(97, 129, 157);
-    --statblock-color-size: rgb(25, 66, 26);
-    --statblock-color-trait: rgb(125, 143, 63);
+
+body.pathfinder-2e-influence-layout-theme-kingmaker .statblock.pathfinder-2e-influence-layout {
+  --statblock-color-common: rgb(54, 69, 79);
+  --statblock-color-uncommon: rgb(143, 85, 66);
+  --statblock-color-rare: rgb(11, 37, 96);
+  --statblock-color-unique: rgb(77, 27, 106);
+  --statblock-color-alignment: rgb(97, 129, 157);
+  --statblock-color-size: rgb(25, 66, 26);
+  --statblock-color-trait: rgb(125, 143, 63);
 }
-body.path2eblockmisc-theme-kingmaker .statblock.basic-pathfinder-2e-layoutmisc {
-    --statblock-color-common: rgb(54, 69, 79);
-    --statblock-color-uncommon: rgb(143, 85, 66);
-    --statblock-color-rare: rgb(11, 37, 96);
-    --statblock-color-unique: rgb(77, 27, 106);
-    --statblock-color-alignment: rgb(97, 129, 157);
-    --statblock-color-size: rgb(25, 66, 26);
-    --statblock-color-trait: rgb(125, 143, 63);
+
+body.pathfinder-2e-misc-layout-theme-kingmaker .statblock.pathfinder-2e-misc-layout {
+  --statblock-color-common: rgb(54, 69, 79);
+  --statblock-color-uncommon: rgb(143, 85, 66);
+  --statblock-color-rare: rgb(11, 37, 96);
+  --statblock-color-unique: rgb(77, 27, 106);
+  --statblock-color-alignment: rgb(97, 129, 157);
+  --statblock-color-size: rgb(25, 66, 26);
+  --statblock-color-trait: rgb(125, 143, 63);
 }
-body.path2eblockquest-theme-kingmaker .statblock.basic-pathfinder-2e-layoutquest {
-    --statblock-color-common: rgb(54, 69, 79);
-    --statblock-color-uncommon: rgb(143, 85, 66);
-    --statblock-color-rare: rgb(11, 37, 96);
-    --statblock-color-unique: rgb(77, 27, 106);
-    --statblock-color-alignment: rgb(97, 129, 157);
-    --statblock-color-size: rgb(25, 66, 26);
-    --statblock-color-trait: rgb(125, 143, 63);
+
+body.pathfinder-2e-quest-layout-theme-kingmaker .statblock.pathfinder-2e-quest-layout {
+  --statblock-color-common: rgb(54, 69, 79);
+  --statblock-color-uncommon: rgb(143, 85, 66);
+  --statblock-color-rare: rgb(11, 37, 96);
+  --statblock-color-unique: rgb(77, 27, 106);
+  --statblock-color-alignment: rgb(97, 129, 157);
+  --statblock-color-size: rgb(25, 66, 26);
+  --statblock-color-trait: rgb(125, 143, 63);
 }
-body.path2eblockset-theme-kingmaker .statblock.basic-pathfinder-2e-layoutset {
-    --statblock-color-common: rgb(54, 69, 79);
-    --statblock-color-uncommon: rgb(143, 85, 66);
-    --statblock-color-rare: rgb(11, 37, 96);
-    --statblock-color-unique: rgb(77, 27, 106);
-    --statblock-color-alignment: rgb(97, 129, 157);
-    --statblock-color-size: rgb(25, 66, 26);
-    --statblock-color-trait: rgb(125, 143, 63);
+
+body.pathfinder-2e-settlement-layout-theme-kingmaker .statblock.pathfinder-2e-settlement-layout {
+  --statblock-color-common: rgb(54, 69, 79);
+  --statblock-color-uncommon: rgb(143, 85, 66);
+  --statblock-color-rare: rgb(11, 37, 96);
+  --statblock-color-unique: rgb(77, 27, 106);
+  --statblock-color-alignment: rgb(97, 129, 157);
+  --statblock-color-size: rgb(25, 66, 26);
+  --statblock-color-trait: rgb(125, 143, 63);
 }
+
 .statblock.basic-pathfinder-2e-layout {
-    --statblock-color-common: rgb(54, 69, 79);
-    --statblock-color-uncommon: rgb(143, 85, 66);
-    --statblock-color-rare: rgb(11, 37, 96);
-    --statblock-color-unique: rgb(77, 27, 106);
-    --statblock-color-alignment: rgb(89, 98, 143);
-    --statblock-color-size: rgb(75, 122, 92);
-    --statblock-color-trait: rgb(86, 12, 6);
-    --statblock-primary-color: rgb(51, 51, 51);
-    --statblock-rule-color: rgb(51, 51, 51);
-    --statblock-background-color: rgb(246, 244, 242);
-    --statblock-background-color-alt: rgb(229, 224, 219);
-    --statblock-bar-color: var(--statblock-rule-color);
-    --statblock-bar-border-size: 1px;
-    --statblock-bar-border-color: var(--statblock-rule-color);
-    --statblock-image-width: 75px;
-    --statblock-image-height: 75px;
-    --statblock-image-border-size: 2px;
-    --statblock-image-border-color: rgb(51, 51, 51);
-    --statblock-border-size: 1px;
-    --statblock-border-color: rgb(51, 51, 51);
-    --statblock-box-shadow-color: rgb(255, 215, 0);
-    --statblock-box-shadow-x-offset: 0;
-    --statblock-box-shadow-y-offset: 0;
-    --statblock-box-shadow-blur: 1.5em;
-    --statblock-font-color: var(--statblock-primary-color);
-    --statblock-font-weight: 400;
-    --statblock-content-font: system-ui, "Pathfinder", -apple-system,
-        BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-        "Open Sans", "Helvetica Neue", sans-serif;
-    --statblock-content-font-size: 13px;
-    --statblock-heading-font: system-ui, "Pathfinder", -apple-system,
-        BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-        "Open Sans", "Helvetica Neue", sans-serif;
-    --statblock-heading-font-color: var(--statblock-font-color);
-    --statblock-heading-font-size: 1.35em;
-    --statblock-heading-font-variant: small-caps;
-    --statblock-heading-font-weight: 700;
-    --statblock-heading-line-height: 1;
-    --statblock-property-line-height: 1.33em;
-    --statblock-property-font-color: var(--statblock-font-color);
-    --statblock-property-name-font-color: var(--statblock-font-color);
-    --statblock-property-name-font-weight: bold;
-    --statblock-section-heading-border-size: 1px;
-    --statblock-section-heading-border-color: transparent;
-    --statblock-section-heading-font-color: var(--statblock-font-color);
-    --statblock-section-heading-font-size: 1.33 empx;
-    --statblock-section-heading-font-variant: small-caps;
-    --statblock-section-heading-font-weight: 400;
-    --statblock-saves-line-height: 1.33em;
-    --statblock-spells-font-style: italic;
-    --statblock-table-header-font-weight: bold;
-    --statblock-other-font: system-ui, "Pathfinder", -apple-system,
-        BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-        "Open Sans", "Helvetica Neue", sans-serif;
-    --statblock-traits-font: system-ui, "Pathfinder", -apple-system,
-        BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-        "Open Sans", "Helvetica Neue", sans-serif;
-    --statblock-text-normal: rgb(--color-base-100);
-    --statblock-text-muted: rgb(--color-base-50);
-    --statblock-text-faint: rgba(--statblock-primary-color, 0.5);
-    --statblock-hyperlink-color: rgb(61, 102, 142);
-    --statblock-hyperlink-text-decoration: rgb(51, 51, 51) underline solid;
-    --statblock-hyperlink-text-shadow: 0.5px 0.5px 0.5px rgba(61, 102, 142);
-    --statblock-italic-font-color: rgb(77, 27, 105);
-    --statblock-h3-variant: small-caps;
-    --statblock-h3-letter-spacing: 1;
-    --statblock-h3-line-height: 1.33em;
-    --statblock-h3-size: 13px;
-    --statblock-h3-color: rgb(51, 51, 51);
-    --statblock-h3-weight: 400;
-    --statblock-h3-font-style: normal;
-    --statblock-h3-font-family: system-ui, "Pathfinder", -apple-system,
-        BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-        "Open Sans", "Helvetica Neue", sans-serif;
-    --statblock-column-width: 400px;
-    --statblock-column2-width: 1000px;
-    --statblock-traits-box-sizing: border-box;
-    --statblock-traits-font-color: rgb(255, 255, 255);
-    --statblock-traits-letter-spacing: 0.01em;
-    --statblock-traits-gap: 2px;
-    --statblock-traits-margins: 0 var(--statblock-traits-gap) 0 0;
-    --statblock-traits-min-width: 4em;
-    --statblock-traits-padding: 0.4em 1.1em 0.2em;
-    --statblock-traits-text-align: center;
-    --statblock-traits-text-transform: uppercase;
-    --statblock-traits-font-size: 12px;
-    --statblock-traits-font-style: normal;
-    --statblock-traits-font-weight: 900;
-    --statblock-list-bullet-border: none;
-    --statblock-list-bullet-radius: 50%;
-    --statblock-list-bullet-size: 0.3em;
-    --statblock-list-bullet-transform: none;
-    --statblock-list-numbered-style: decimal;
-    --statblock-list-indent: 2em;
-    --statblock-list-margin-block-start: 1em;
-    --statblock-list-margin-block-end: 1em;
-    --statblock-list-margin-inline-start: 0px;
-    --statblock-list-margin-inline-end: 0px;
-    --statblock-list-marker-color: blue;
-    --statblock-list-marker-color-collapsed: var(--text-accent);
-    --statblock-list-marker-color-hover: var(--text-muted);
-    --statblock-list-padding-inline-start: 40px;
-    --statblock-list-padding-top: 0;
-    --statblock-list-padding-bottom: 0;
-    --statblock-list-spacing: 0.075em;
-    --statblock-list-style-type: disc;
-    --statblock-list-text-align: -webkit-match-parent;
-    --statblock-upper-level-padding: 2em;
-    --statblock-upper-level-margin: 2em;
+  --statblock-color-common: rgb(54, 69, 79);
+  --statblock-color-uncommon: rgb(143, 85, 66);
+  --statblock-color-rare: rgb(11, 37, 96);
+  --statblock-color-unique: rgb(77, 27, 106);
+  --statblock-color-alignment: rgb(89, 98, 143);
+  --statblock-color-size: rgb(75, 122, 92);
+  --statblock-color-trait: rgb(86, 12, 6);
+  --statblock-primary-color: rgb(51, 51, 51);
+  --statblock-rule-color: rgb(51, 51, 51);
+  --statblock-background-color: rgb(246, 244, 242);
+  --statblock-bar-color: rgb(51, 51, 51);
+  --statblock-bar-border-size: 1px;
+  --statblock-bar-border-color: rgb(51, 51, 51);
+  --statblock-image-width: 75px;
+  --statblock-image-height: 75px;
+  --statblock-image-border-size: 2px;
+  --statblock-image-border-color: rgb(51, 51, 51);
+  --statblock-header-image-height: 22px;
+  --statblock-header-image-padding: 0 0 2px 0;
+  --statblock-border-size: 1px;
+  --statblock-border-color: rgb(51, 51, 51);
+  --statblock-box-shadow-color: none;
+  --statblock-box-shadow-x-offset: 0;
+  --statblock-box-shadow-y-offset: 0;
+  --statblock-box-shadow-blur: 1.5em;
+  --statblock-font-color: rgb(51, 51, 51);
+  --statblock-font-weight: 400;
+  --statblock-content-font: system-ui, "Pathfinder", -apple-system,
+  BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
+  "Open Sans", "Helvetica Neue", sans-serif;
+  --statblock-content-font-size: 13px;
+  --statblock-heading-font: system-ui, "Pathfinder", -apple-system,
+  BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
+  "Open Sans", "Helvetica Neue", sans-serif;
+  --statblock-heading-font-color: rgb(51, 51, 51);
+  --statblock-heading-font-size: 1.35em;
+  --statblock-heading-font-variant: small-caps;
+  --statblock-heading-font-weight: 700;
+  --statblock-heading-line-height: 1;
+  --statblock-property-line-height: 1.33em;
+  --statblock-property-font-color: rgb(51, 51, 51);
+  --statblock-property-name-font-color: rgb(51, 51, 51);
+  --statblock-property-name-font-weight: bold;
+  --statblock-section-heading-border-size: 1px;
+  --statblock-section-heading-border-color: transparent;
+  --statblock-section-heading-font-color: rgb(51, 51, 51);
+  --statblock-section-heading-font-size: 1.33em;
+  --statblock-section-heading-font-variant: small-caps;
+  --statblock-section-heading-font-weight: 400;
+  --statblock-saves-line-height: 1.33em;
+  --statblock-spells-font-style: italic;
+  --statblock-table-header-font-weight: bold;
+  --statblock-column-width: 400px;
+  --statblock-traits-gap: 2px;
 }
-.statblock.basic-pathfinder-2e-layout .bar {
-    height: 1px;
-    background: var(--statblock-bar-color);
-    border: var(--statblock-bar-border-size) solid
-        var(--statblock-bar-border-color);
-    z-index: 1;
-    width: fit-content;
+
+.statblock.pathfinder-2e-action-layout {
+  --statblock-color-common: rgb(54, 69, 79);
+  --statblock-color-uncommon: rgb(143, 85, 66);
+  --statblock-color-rare: rgb(11, 37, 96);
+  --statblock-color-unique: rgb(77, 27, 106);
+  --statblock-color-alignment: rgb(89, 98, 143);
+  --statblock-color-size: rgb(75, 122, 92);
+  --statblock-color-trait: rgb(86, 12, 6);
+  --statblock-primary-color: rgb(51, 51, 51);
+  --statblock-rule-color: rgb(51, 51, 51);
+  --statblock-background-color: rgb(246, 244, 242);
+  --statblock-bar-color: rgb(51, 51, 51);
+  --statblock-bar-border-size: 1px;
+  --statblock-bar-border-color: rgb(51, 51, 51);
+  --statblock-image-width: 75px;
+  --statblock-image-height: 75px;
+  --statblock-image-border-size: 2px;
+  --statblock-image-border-color: rgb(51, 51, 51);
+  --statblock-header-image-height: 22px;
+  --statblock-header-image-padding: 0 0 2px 0;
+  --statblock-border-size: 1px;
+  --statblock-border-color: rgb(51, 51, 51);
+  --statblock-box-shadow-color: none;
+  --statblock-box-shadow-x-offset: 0;
+  --statblock-box-shadow-y-offset: 0;
+  --statblock-box-shadow-blur: 1.5em;
+  --statblock-font-color: rgb(51, 51, 51);
+  --statblock-font-weight: 400;
+  --statblock-content-font: system-ui, "Pathfinder", -apple-system,
+  BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
+  "Open Sans", "Helvetica Neue", sans-serif;
+  --statblock-content-font-size: 13px;
+  --statblock-heading-font: system-ui, "Pathfinder", -apple-system,
+  BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
+  "Open Sans", "Helvetica Neue", sans-serif;
+  --statblock-heading-font-color: rgb(51, 51, 51);
+  --statblock-heading-font-size: 1.35em;
+  --statblock-heading-font-variant: small-caps;
+  --statblock-heading-font-weight: 700;
+  --statblock-heading-line-height: 1;
+  --statblock-property-line-height: 1.33em;
+  --statblock-property-font-color: rgb(51, 51, 51);
+  --statblock-property-name-font-color: rgb(51, 51, 51);
+  --statblock-property-name-font-weight: bold;
+  --statblock-section-heading-border-size: 1px;
+  --statblock-section-heading-border-color: transparent;
+  --statblock-section-heading-font-color: rgb(51, 51, 51);
+  --statblock-section-heading-font-size: 1.33em;
+  --statblock-section-heading-font-variant: small-caps;
+  --statblock-section-heading-font-weight: 400;
+  --statblock-saves-line-height: 1.33em;
+  --statblock-spells-font-style: italic;
+  --statblock-table-header-font-weight: bold;
+  --statblock-column-width: 400px;
+  --statblock-traits-gap: 2px;
 }
+
+.statblock.pathfinder-2e-hazard-layout {
+  --statblock-color-common: rgb(54, 69, 79);
+  --statblock-color-uncommon: rgb(143, 85, 66);
+  --statblock-color-rare: rgb(11, 37, 96);
+  --statblock-color-unique: rgb(77, 27, 106);
+  --statblock-color-alignment: rgb(89, 98, 143);
+  --statblock-color-size: rgb(75, 122, 92);
+  --statblock-color-trait: rgb(86, 12, 6);
+  --statblock-primary-color: rgb(51, 51, 51);
+  --statblock-rule-color: rgb(51, 51, 51);
+  --statblock-background-color: rgb(246, 244, 242);
+  --statblock-bar-color: rgb(51, 51, 51);
+  --statblock-bar-border-size: 1px;
+  --statblock-bar-border-color: rgb(51, 51, 51);
+  --statblock-image-width: 75px;
+  --statblock-image-height: 75px;
+  --statblock-image-border-size: 2px;
+  --statblock-image-border-color: rgb(51, 51, 51);
+  --statblock-header-image-height: 22px;
+  --statblock-header-image-padding: 0 0 2px 0;
+  --statblock-border-size: 1px;
+  --statblock-border-color: rgb(51, 51, 51);
+  --statblock-box-shadow-color: none;
+  --statblock-box-shadow-x-offset: 0;
+  --statblock-box-shadow-y-offset: 0;
+  --statblock-box-shadow-blur: 1.5em;
+  --statblock-font-color: rgb(51, 51, 51);
+  --statblock-font-weight: 400;
+  --statblock-content-font: system-ui, "Pathfinder", -apple-system,
+  BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
+  "Open Sans", "Helvetica Neue", sans-serif;
+  --statblock-content-font-size: 13px;
+  --statblock-heading-font: system-ui, "Pathfinder", -apple-system,
+  BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
+  "Open Sans", "Helvetica Neue", sans-serif;
+  --statblock-heading-font-color: rgb(51, 51, 51);
+  --statblock-heading-font-size: 1.35em;
+  --statblock-heading-font-variant: small-caps;
+  --statblock-heading-font-weight: 700;
+  --statblock-heading-line-height: 1;
+  --statblock-property-line-height: 1.33em;
+  --statblock-property-font-color: rgb(51, 51, 51);
+  --statblock-property-name-font-color: rgb(51, 51, 51);
+  --statblock-property-name-font-weight: bold;
+  --statblock-section-heading-border-size: 1px;
+  --statblock-section-heading-border-color: transparent;
+  --statblock-section-heading-font-color: rgb(51, 51, 51);
+  --statblock-section-heading-font-size: 1.33em;
+  --statblock-section-heading-font-variant: small-caps;
+  --statblock-section-heading-font-weight: 400;
+  --statblock-saves-line-height: 1.33em;
+  --statblock-spells-font-style: italic;
+  --statblock-table-header-font-weight: bold;
+  --statblock-column-width: 400px;
+  --statblock-traits-gap: 2px;
+}
+
+.statblock.pathfinder-2e-influence-layout {
+  --statblock-color-common: rgb(54, 69, 79);
+  --statblock-color-uncommon: rgb(143, 85, 66);
+  --statblock-color-rare: rgb(11, 37, 96);
+  --statblock-color-unique: rgb(77, 27, 106);
+  --statblock-color-alignment: rgb(89, 98, 143);
+  --statblock-color-size: rgb(75, 122, 92);
+  --statblock-color-trait: rgb(86, 12, 6);
+  --statblock-primary-color: rgb(51, 51, 51);
+  --statblock-rule-color: rgb(51, 51, 51);
+  --statblock-background-color: rgb(246, 244, 242);
+  --statblock-bar-color: rgb(51, 51, 51);
+  --statblock-bar-border-size: 1px;
+  --statblock-bar-border-color: rgb(51, 51, 51);
+  --statblock-image-width: 75px;
+  --statblock-image-height: 75px;
+  --statblock-image-border-size: 2px;
+  --statblock-image-border-color: rgb(51, 51, 51);
+  --statblock-header-image-height: 22px;
+  --statblock-header-image-padding: 0 0 2px 0;
+  --statblock-border-size: 1px;
+  --statblock-border-color: rgb(51, 51, 51);
+  --statblock-box-shadow-color: none;
+  --statblock-box-shadow-x-offset: 0;
+  --statblock-box-shadow-y-offset: 0;
+  --statblock-box-shadow-blur: 1.5em;
+  --statblock-font-color: rgb(51, 51, 51);
+  --statblock-font-weight: 400;
+  --statblock-content-font: system-ui, "Pathfinder", -apple-system,
+  BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
+  "Open Sans", "Helvetica Neue", sans-serif;
+  --statblock-content-font-size: 13px;
+  --statblock-heading-font: system-ui, "Pathfinder", -apple-system,
+  BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
+  "Open Sans", "Helvetica Neue", sans-serif;
+  --statblock-heading-font-color: rgb(51, 51, 51);
+  --statblock-heading-font-size: 1.35em;
+  --statblock-heading-font-variant: small-caps;
+  --statblock-heading-font-weight: 700;
+  --statblock-heading-line-height: 1;
+  --statblock-property-line-height: 1.33em;
+  --statblock-property-font-color: rgb(51, 51, 51);
+  --statblock-property-name-font-color: rgb(51, 51, 51);
+  --statblock-property-name-font-weight: bold;
+  --statblock-section-heading-border-size: 1px;
+  --statblock-section-heading-border-color: transparent;
+  --statblock-section-heading-font-color: rgb(51, 51, 51);
+  --statblock-section-heading-font-size: 1.33em;
+  --statblock-section-heading-font-variant: small-caps;
+  --statblock-section-heading-font-weight: 400;
+  --statblock-saves-line-height: 1.33em;
+  --statblock-spells-font-style: italic;
+  --statblock-table-header-font-weight: bold;
+  --statblock-column-width: 400px;
+  --statblock-traits-gap: 2px;
+}
+
+.statblock.pathfinder-2e-misc-layout {
+  --statblock-color-common: rgb(54, 69, 79);
+  --statblock-color-uncommon: rgb(143, 85, 66);
+  --statblock-color-rare: rgb(11, 37, 96);
+  --statblock-color-unique: rgb(77, 27, 106);
+  --statblock-color-alignment: rgb(89, 98, 143);
+  --statblock-color-size: rgb(75, 122, 92);
+  --statblock-color-trait: rgb(86, 12, 6);
+  --statblock-primary-color: rgb(51, 51, 51);
+  --statblock-rule-color: rgb(51, 51, 51);
+  --statblock-background-color: rgb(246, 244, 242);
+  --statblock-bar-color: rgb(51, 51, 51);
+  --statblock-bar-border-size: 1px;
+  --statblock-bar-border-color: rgb(51, 51, 51);
+  --statblock-image-width: 75px;
+  --statblock-image-height: 75px;
+  --statblock-image-border-size: 2px;
+  --statblock-image-border-color: rgb(51, 51, 51);
+  --statblock-header-image-height: 22px;
+  --statblock-header-image-padding: 0 0 2px 0;
+  --statblock-border-size: 1px;
+  --statblock-border-color: rgb(51, 51, 51);
+  --statblock-box-shadow-color: none;
+  --statblock-box-shadow-x-offset: 0;
+  --statblock-box-shadow-y-offset: 0;
+  --statblock-box-shadow-blur: 1.5em;
+  --statblock-font-color: rgb(51, 51, 51);
+  --statblock-font-weight: 400;
+  --statblock-content-font: system-ui, "Pathfinder", -apple-system,
+  BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
+  "Open Sans", "Helvetica Neue", sans-serif;
+  --statblock-content-font-size: 13px;
+  --statblock-heading-font: system-ui, "Pathfinder", -apple-system,
+  BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
+  "Open Sans", "Helvetica Neue", sans-serif;
+  --statblock-heading-font-color: rgb(51, 51, 51);
+  --statblock-heading-font-size: 1.35em;
+  --statblock-heading-font-variant: small-caps;
+  --statblock-heading-font-weight: 700;
+  --statblock-heading-line-height: 1;
+  --statblock-property-line-height: 1.33em;
+  --statblock-property-font-color: rgb(51, 51, 51);
+  --statblock-property-name-font-color: rgb(51, 51, 51);
+  --statblock-property-name-font-weight: bold;
+  --statblock-section-heading-border-size: 1px;
+  --statblock-section-heading-border-color: transparent;
+  --statblock-section-heading-font-color: rgb(51, 51, 51);
+  --statblock-section-heading-font-size: 1.33em;
+  --statblock-section-heading-font-variant: small-caps;
+  --statblock-section-heading-font-weight: 400;
+  --statblock-saves-line-height: 1.33em;
+  --statblock-spells-font-style: italic;
+  --statblock-table-header-font-weight: bold;
+  --statblock-column-width: 400px;
+  --statblock-traits-gap: 2px;
+}
+
+.statblock.pathfinder-2e-quest-layout {
+  --statblock-color-common: rgb(54, 69, 79);
+  --statblock-color-uncommon: rgb(143, 85, 66);
+  --statblock-color-rare: rgb(11, 37, 96);
+  --statblock-color-unique: rgb(77, 27, 106);
+  --statblock-color-alignment: rgb(89, 98, 143);
+  --statblock-color-size: rgb(75, 122, 92);
+  --statblock-color-trait: rgb(86, 12, 6);
+  --statblock-primary-color: rgb(51, 51, 51);
+  --statblock-rule-color: rgb(51, 51, 51);
+  --statblock-background-color: rgb(246, 244, 242);
+  --statblock-bar-color: rgb(51, 51, 51);
+  --statblock-bar-border-size: 1px;
+  --statblock-bar-border-color: rgb(51, 51, 51);
+  --statblock-image-width: 75px;
+  --statblock-image-height: 75px;
+  --statblock-image-border-size: 2px;
+  --statblock-image-border-color: rgb(51, 51, 51);
+  --statblock-header-image-height: 22px;
+  --statblock-header-image-padding: 0 0 2px 0;
+  --statblock-border-size: 1px;
+  --statblock-border-color: rgb(51, 51, 51);
+  --statblock-box-shadow-color: none;
+  --statblock-box-shadow-x-offset: 0;
+  --statblock-box-shadow-y-offset: 0;
+  --statblock-box-shadow-blur: 1.5em;
+  --statblock-font-color: rgb(51, 51, 51);
+  --statblock-font-weight: 400;
+  --statblock-content-font: system-ui, "Pathfinder", -apple-system,
+  BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
+  "Open Sans", "Helvetica Neue", sans-serif;
+  --statblock-content-font-size: 13px;
+  --statblock-heading-font: system-ui, "Pathfinder", -apple-system,
+  BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
+  "Open Sans", "Helvetica Neue", sans-serif;
+  --statblock-heading-font-color: rgb(51, 51, 51);
+  --statblock-heading-font-size: 1.35em;
+  --statblock-heading-font-variant: small-caps;
+  --statblock-heading-font-weight: 700;
+  --statblock-heading-line-height: 1;
+  --statblock-property-line-height: 1.33em;
+  --statblock-property-font-color: rgb(51, 51, 51);
+  --statblock-property-name-font-color: rgb(51, 51, 51);
+  --statblock-property-name-font-weight: bold;
+  --statblock-section-heading-border-size: 1px;
+  --statblock-section-heading-border-color: transparent;
+  --statblock-section-heading-font-color: rgb(51, 51, 51);
+  --statblock-section-heading-font-size: 1.33em;
+  --statblock-section-heading-font-variant: small-caps;
+  --statblock-section-heading-font-weight: 400;
+  --statblock-saves-line-height: 1.33em;
+  --statblock-spells-font-style: italic;
+  --statblock-table-header-font-weight: bold;
+  --statblock-column-width: 400px;
+  --statblock-traits-gap: 2px;
+}
+
+.statblock.pathfinder-2e-settlement-layout {
+  --statblock-color-common: rgb(54, 69, 79);
+  --statblock-color-uncommon: rgb(143, 85, 66);
+  --statblock-color-rare: rgb(11, 37, 96);
+  --statblock-color-unique: rgb(77, 27, 106);
+  --statblock-color-alignment: rgb(89, 98, 143);
+  --statblock-color-size: rgb(75, 122, 92);
+  --statblock-color-trait: rgb(86, 12, 6);
+  --statblock-primary-color: rgb(51, 51, 51);
+  --statblock-rule-color: rgb(51, 51, 51);
+  --statblock-background-color: rgb(246, 244, 242);
+  --statblock-bar-color: rgb(51, 51, 51);
+  --statblock-bar-border-size: 1px;
+  --statblock-bar-border-color: rgb(51, 51, 51);
+  --statblock-image-width: 75px;
+  --statblock-image-height: 75px;
+  --statblock-image-border-size: 2px;
+  --statblock-image-border-color: rgb(51, 51, 51);
+  --statblock-header-image-height: 22px;
+  --statblock-header-image-padding: 0 0 2px 0;
+  --statblock-border-size: 1px;
+  --statblock-border-color: rgb(51, 51, 51);
+  --statblock-box-shadow-color: none;
+  --statblock-box-shadow-x-offset: 0;
+  --statblock-box-shadow-y-offset: 0;
+  --statblock-box-shadow-blur: 1.5em;
+  --statblock-font-color: rgb(51, 51, 51);
+  --statblock-font-weight: 400;
+  --statblock-content-font: system-ui, "Pathfinder", -apple-system,
+  BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
+  "Open Sans", "Helvetica Neue", sans-serif;
+  --statblock-content-font-size: 13px;
+  --statblock-heading-font: system-ui, "Pathfinder", -apple-system,
+  BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
+  "Open Sans", "Helvetica Neue", sans-serif;
+  --statblock-heading-font-color: rgb(51, 51, 51);
+  --statblock-heading-font-size: 1.35em;
+  --statblock-heading-font-variant: small-caps;
+  --statblock-heading-font-weight: 700;
+  --statblock-heading-line-height: 1;
+  --statblock-property-line-height: 1.33em;
+  --statblock-property-font-color: rgb(51, 51, 51);
+  --statblock-property-name-font-color: rgb(51, 51, 51);
+  --statblock-property-name-font-weight: bold;
+  --statblock-section-heading-border-size: 1px;
+  --statblock-section-heading-border-color: transparent;
+  --statblock-section-heading-font-color: rgb(51, 51, 51);
+  --statblock-section-heading-font-size: 1.33em;
+  --statblock-section-heading-font-variant: small-caps;
+  --statblock-section-heading-font-weight: 400;
+  --statblock-saves-line-height: 1.33em;
+  --statblock-spells-font-style: italic;
+  --statblock-table-header-font-weight: bold;
+  --statblock-column-width: 400px;
+  --statblock-traits-gap: 2px;
+}
+
 .statblock.basic-pathfinder-2e-layout .statblock-content {
-    font-family: var(--statblock-content-font);
-    font-size: var(--statblock-content-font-size);
-    color: var(--statblock-font-color);
-    background-color: var(--statblock-background-color);
-    padding: 0.5em;
-    border: var(--statblock-border-size) var(--statblock-border-color) solid;
-    box-shadow: var(--statblock-box-shadow-x-offset)
-        var(--statblock-box-shadow-y-offset) var(--statblock-box-shadow-blur)
-        var(--statblock-box-shadow-color);
-    margin: 0.5em 2px;
-    display: flex;
-    gap: 1rem;
+  background-color: var(--statblock-background-color);
+  border: var(--statblock-border-size) var(--statblock-border-color) solid;
+  box-shadow: none;
+  color: var(--statblock-property-font-color);
+  display: flex;
+  font-family: var(--statblock-content-font);
+  font-size: var(--statblock-content-font-size);
+  margin: 0.5em 2px;
+  padding: 0.5em;
+  gap: 1rem;
 }
 .statblock.basic-pathfinder-2e-layout .statblock-content .statblock-detached {
-    position: absolute;
-    top: -9999px;
+  position: absolute;
+  top: -9999px;
 }
 .statblock.basic-pathfinder-2e-layout .statblock-content .statblock-item-container {
-    margin: 0;
-    padding: 0;
+  margin: 0;
+  padding: 0;
 }
 .statblock.basic-pathfinder-2e-layout .statblock-content .statblock-item-inline {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    align-content: flex-start;
-    align-items: baseline;
-    justify-content: flex-start;
-    margin: 0;
-    padding: 0;
+  align-content: flex-start;
+  align-items: baseline;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  margin: 0;
+  padding: 0;
 }
 .statblock.basic-pathfinder-2e-layout .statblock-content > .column {
-    width: var(--statblock-column-width);
+  width: var(--statblock-column-width);
+  /* Hazard Block Specific */
 }
-.statblock.basic-pathfinder-2e-layout
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline) {
+.statblock.basic-pathfinder-2e-layout .statblock-content > .column > :is(.statblock-item-container, .statblock-item-inline):has(.line, .property) {
+  margin-block: 0.25rem;
 }
-.statblock.basic-pathfinder-2e-layout
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline):has(
-        .line,
-        .property
-    ) {
-    margin-block: 0.25rem;
+.statblock.basic-pathfinder-2e-layout .statblock-content > .column > :is(.statblock-item-container, .statblock-item-inline):has(.line, .property):last-child {
+  margin-bottom: 0;
 }
-.statblock.basic-pathfinder-2e-layout
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline):has(
-        .line,
-        .property
-    ):last-child {
-    margin-bottom: 0;
+.statblock.basic-pathfinder-2e-layout .statblock-content > .column > :is(.statblock-item-container, .statblock-item-inline):has(.line.name) {
+  margin: 0;
 }
-.statblock.basic-pathfinder-2e-layout
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline):has(.line.name) {
-    margin: 0;
+.statblock.basic-pathfinder-2e-layout .statblock-content > .column > :is(.statblock-item-container, .statblock-item-inline) > :is(.property, .line:has(.property-name)) {
+  margin-left: 1em;
 }
-.statblock.basic-pathfinder-2e-layout
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline)
-    > :is(.property, .line:has(.property-name)) {
-    margin-left: 1em;
+.statblock.basic-pathfinder-2e-layout .statblock-content > .column > :is(.statblock-item-container, .statblock-item-inline) > :is(.property, .line) .property-name {
+  margin-left: -1em;
 }
-.statblock.basic-pathfinder-2e-layout
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline)
-    > :is(.property, .line)
-    .property-name {
-    margin-left: -1em;
+.statblock.basic-pathfinder-2e-layout .statblock-content > .column > .statblock-item-container:has(.tapered-rule) {
+  margin-block: 0.25rem;
 }
-.statblock.basic-pathfinder-2e-layout
-    .statblock-content
-    > .column
-    > .statblock-item-container:has(.tapered-rule) {
-    margin-block: 0.25rem;
+.statblock.basic-pathfinder-2e-layout .statblock-content > .column > .statblock-item-inline:has(.name) + .statblock-item-container:has(.tapered-rule) {
+  margin-top: 0;
 }
-.statblock.basic-pathfinder-2e-layout
-    .statblock-content
-    > .column
-    > .statblock-item-inline:has(.name)
-    + .statblock-item-container:has(.tapered-rule) {
-    margin-top: 0;
+.statblock.basic-pathfinder-2e-layout .statblock-content > .column > .statblock-item-inline:has(.rare_01,
+.rare_02,
+.rare_03,
+.rare_04,
+.alignment,
+.size,
+.xp,
+.kingdom_xp,
+.trait_01,
+.trait_02,
+.trait_03,
+.trait_04,
+.trait_05,
+.trait_06,
+.trait_07) {
+  row-gap: var(--statblock-traits-gap);
+  margin-top: 0.5em;
 }
-.statblock.basic-pathfinder-2e-layout
-    .statblock-content
-    > .column
-    > .statblock-item-inline:has(
-        .rare_01,
-        .rare_02,
-        .rare_03,
-        .rare_04,
-        .alignment,
-        .size,
-        .xp,
-        .kingdom_xp,
-        .trait_01,
-        .trait_02,
-        .trait_03,
-        .trait_04,
-        .trait_05,
-        .trait_06,
-        .trait_07
-    ) {
-    row-gap: var(--statblock-traits-gap);
-    margin-top: 0.5em;
+
+.statblock.pathfinder-2e-action-layout .statblock-content {
+  background-color: var(--statblock-background-color);
+  border: var(--statblock-border-size) var(--statblock-border-color) solid;
+  box-shadow: none;
+  color: var(--statblock-property-font-color);
+  display: flex;
+  font-family: var(--statblock-content-font);
+  font-size: var(--statblock-content-font-size);
+  margin: 0.5em 2px;
+  padding: 0.5em;
+  gap: 1rem;
 }
-@media screen and (max-width: 400px) {
-    .statblock.basic-pathfinder-2e-layout .statblock-content > :global(.column) {
-        width: 75vw;
-    }
+.statblock.pathfinder-2e-action-layout .statblock-content .statblock-detached {
+  position: absolute;
+  top: -9999px;
 }
-.statblock.basic-pathfinder-2e-layout .dice-roller-result {
-    font-weight: var(--statblock-font-weight);
+.statblock.pathfinder-2e-action-layout .statblock-content .statblock-item-container {
+  margin: 0;
+  padding: 0;
 }
-.statblock.basic-pathfinder-2e-layout .roller-result {
-    font-weight: var(--statblock-font-weight);
+.statblock.pathfinder-2e-action-layout .statblock-content .statblock-item-inline {
+  align-content: flex-start;
+  align-items: baseline;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  margin: 0;
+  padding: 0;
 }
-.statblock.basic-pathfinder-2e-layout .image {
-    width: var(--statblock-image-width);
-    height: var(--statblock-image-height);
+.statblock.pathfinder-2e-action-layout .statblock-content > .column {
+  width: var(--statblock-column-width);
+  /* Hazard Block Specific */
 }
-.statblock.basic-pathfinder-2e-layout .image.pointer {
-    cursor: pointer;
+.statblock.pathfinder-2e-action-layout .statblock-content > .column > :is(.statblock-item-container, .statblock-item-inline):has(.line, .property) {
+  margin-block: 0.25rem;
 }
-.statblock.basic-pathfinder-2e-layout .image img {
-    object-fit: cover;
-    width: 100%;
-    height: 100%;
-    border-radius: 100%;
-    border: var(--statblock-image-border-size) solid
-        var(--statblock-image-border-color);
-    object-position: center;
+.statblock.pathfinder-2e-action-layout .statblock-content > .column > :is(.statblock-item-container, .statblock-item-inline):has(.line, .property):last-child {
+  margin-bottom: 0;
 }
+.statblock.pathfinder-2e-action-layout .statblock-content > .column > :is(.statblock-item-container, .statblock-item-inline):has(.line.name) {
+  margin: 0;
+}
+.statblock.pathfinder-2e-action-layout .statblock-content > .column > :is(.statblock-item-container, .statblock-item-inline) > :is(.property, .line:has(.property-name)) {
+  margin-left: 1em;
+}
+.statblock.pathfinder-2e-action-layout .statblock-content > .column > :is(.statblock-item-container, .statblock-item-inline) > :is(.property, .line) .property-name {
+  margin-left: -1em;
+}
+.statblock.pathfinder-2e-action-layout .statblock-content > .column > .statblock-item-container:has(.tapered-rule) {
+  margin-block: 0.25rem;
+}
+.statblock.pathfinder-2e-action-layout .statblock-content > .column > .statblock-item-inline:has(.name) + .statblock-item-container:has(.tapered-rule) {
+  margin-top: 0;
+}
+.statblock.pathfinder-2e-action-layout .statblock-content > .column > .statblock-item-inline:has(.rare_01,
+.rare_02,
+.rare_03,
+.rare_04,
+.alignment,
+.size,
+.xp,
+.kingdom_xp,
+.trait_01,
+.trait_02,
+.trait_03,
+.trait_04,
+.trait_05,
+.trait_06,
+.trait_07) {
+  row-gap: var(--statblock-traits-gap);
+  margin-bottom: 0.5em;
+}
+
+.statblock.pathfinder-2e-hazard-layout .statblock-content {
+  background-color: var(--statblock-background-color);
+  border: var(--statblock-border-size) var(--statblock-border-color) solid;
+  box-shadow: none;
+  color: var(--statblock-property-font-color);
+  display: flex;
+  font-family: var(--statblock-content-font);
+  font-size: var(--statblock-content-font-size);
+  margin: 0.5em 2px;
+  padding: 0.5em;
+  gap: 1rem;
+}
+.statblock.pathfinder-2e-hazard-layout .statblock-content .statblock-detached {
+  position: absolute;
+  top: -9999px;
+}
+.statblock.pathfinder-2e-hazard-layout .statblock-content .statblock-item-container {
+  margin: 0;
+  padding: 0;
+}
+.statblock.pathfinder-2e-hazard-layout .statblock-content .statblock-item-inline {
+  align-content: flex-start;
+  align-items: baseline;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  margin: 0;
+  padding: 0;
+}
+.statblock.pathfinder-2e-hazard-layout .statblock-content > .column {
+  width: var(--statblock-column-width);
+  /* Hazard Block Specific */
+}
+.statblock.pathfinder-2e-hazard-layout .statblock-content > .column > :is(.statblock-item-container, .statblock-item-inline):has(.line, .property) {
+  margin-block: 0.25rem;
+}
+.statblock.pathfinder-2e-hazard-layout .statblock-content > .column > :is(.statblock-item-container, .statblock-item-inline):has(.line, .property):last-child {
+  margin-bottom: 0;
+}
+.statblock.pathfinder-2e-hazard-layout .statblock-content > .column > :is(.statblock-item-container, .statblock-item-inline):has(.line.name) {
+  margin: 0;
+}
+.statblock.pathfinder-2e-hazard-layout .statblock-content > .column > :is(.statblock-item-container, .statblock-item-inline) > :is(.property, .line:has(.property-name)) {
+  margin-left: 1em;
+}
+.statblock.pathfinder-2e-hazard-layout .statblock-content > .column > :is(.statblock-item-container, .statblock-item-inline) > :is(.property, .line) .property-name {
+  margin-left: -1em;
+}
+.statblock.pathfinder-2e-hazard-layout .statblock-content > .column > .statblock-item-container:has(.tapered-rule) {
+  margin-block: 0.25rem;
+}
+.statblock.pathfinder-2e-hazard-layout .statblock-content > .column > .statblock-item-inline:has(.name) + .statblock-item-container:has(.tapered-rule) {
+  margin-top: 0;
+}
+.statblock.pathfinder-2e-hazard-layout .statblock-content > .column > .statblock-item-inline:has(.rare_01,
+.rare_02,
+.rare_03,
+.rare_04,
+.alignment,
+.size,
+.xp,
+.kingdom_xp,
+.trait_01,
+.trait_02,
+.trait_03,
+.trait_04,
+.trait_05,
+.trait_06,
+.trait_07) {
+  row-gap: var(--statblock-traits-gap);
+  margin-bottom: 0.5em;
+}
+.statblock.pathfinder-2e-hazard-layout .statblock-content > .column > .statblock-item-container:has(.effect) {
+  margin-left: 1em;
+}
+
+.statblock.pathfinder-2e-influence-layout .statblock-content {
+  background-color: var(--statblock-background-color);
+  border: var(--statblock-border-size) var(--statblock-border-color) solid;
+  box-shadow: none;
+  color: var(--statblock-property-font-color);
+  display: flex;
+  font-family: var(--statblock-content-font);
+  font-size: var(--statblock-content-font-size);
+  margin: 0.5em 2px;
+  padding: 0.5em;
+  gap: 1rem;
+}
+.statblock.pathfinder-2e-influence-layout .statblock-content .statblock-detached {
+  position: absolute;
+  top: -9999px;
+}
+.statblock.pathfinder-2e-influence-layout .statblock-content .statblock-item-container {
+  margin: 0;
+  padding: 0;
+}
+.statblock.pathfinder-2e-influence-layout .statblock-content .statblock-item-inline {
+  align-content: flex-start;
+  align-items: baseline;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  margin: 0;
+  padding: 0;
+}
+.statblock.pathfinder-2e-influence-layout .statblock-content > .column {
+  width: var(--statblock-column-width);
+  /* Hazard Block Specific */
+}
+.statblock.pathfinder-2e-influence-layout .statblock-content > .column > :is(.statblock-item-container, .statblock-item-inline):has(.line, .property) {
+  margin-block: 0.25rem;
+}
+.statblock.pathfinder-2e-influence-layout .statblock-content > .column > :is(.statblock-item-container, .statblock-item-inline):has(.line, .property):last-child {
+  margin-bottom: 0;
+}
+.statblock.pathfinder-2e-influence-layout .statblock-content > .column > :is(.statblock-item-container, .statblock-item-inline):has(.line.name) {
+  margin: 0;
+}
+.statblock.pathfinder-2e-influence-layout .statblock-content > .column > :is(.statblock-item-container, .statblock-item-inline) > :is(.property, .line:has(.property-name)) {
+  margin-left: 1em;
+}
+.statblock.pathfinder-2e-influence-layout .statblock-content > .column > :is(.statblock-item-container, .statblock-item-inline) > :is(.property, .line) .property-name {
+  margin-left: -1em;
+}
+.statblock.pathfinder-2e-influence-layout .statblock-content > .column > .statblock-item-container:has(.tapered-rule) {
+  margin-block: 0.25rem;
+}
+.statblock.pathfinder-2e-influence-layout .statblock-content > .column > .statblock-item-inline:has(.name) + .statblock-item-container:has(.tapered-rule) {
+  margin-top: 0;
+}
+.statblock.pathfinder-2e-influence-layout .statblock-content > .column > .statblock-item-inline:has(.rare_01,
+.rare_02,
+.rare_03,
+.rare_04,
+.alignment,
+.size,
+.xp,
+.kingdom_xp,
+.trait_01,
+.trait_02,
+.trait_03,
+.trait_04,
+.trait_05,
+.trait_06,
+.trait_07) {
+  row-gap: var(--statblock-traits-gap);
+  margin-bottom: 0.5em;
+}
+
+.statblock.pathfinder-2e-misc-layout .statblock-content {
+  background-color: var(--statblock-background-color);
+  border: var(--statblock-border-size) var(--statblock-border-color) solid;
+  box-shadow: none;
+  color: var(--statblock-property-font-color);
+  display: flex;
+  font-family: var(--statblock-content-font);
+  font-size: var(--statblock-content-font-size);
+  margin: 0.5em 2px;
+  padding: 0.5em;
+  gap: 1rem;
+}
+.statblock.pathfinder-2e-misc-layout .statblock-content .statblock-detached {
+  position: absolute;
+  top: -9999px;
+}
+.statblock.pathfinder-2e-misc-layout .statblock-content .statblock-item-container {
+  margin: 0;
+  padding: 0;
+}
+.statblock.pathfinder-2e-misc-layout .statblock-content .statblock-item-inline {
+  align-content: flex-start;
+  align-items: baseline;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  margin: 0;
+  padding: 0;
+}
+.statblock.pathfinder-2e-misc-layout .statblock-content > .column {
+  width: var(--statblock-column-width);
+  /* Hazard Block Specific */
+}
+.statblock.pathfinder-2e-misc-layout .statblock-content > .column > :is(.statblock-item-container, .statblock-item-inline):has(.line, .property) {
+  margin-block: 0.25rem;
+}
+.statblock.pathfinder-2e-misc-layout .statblock-content > .column > :is(.statblock-item-container, .statblock-item-inline):has(.line, .property):last-child {
+  margin-bottom: 0;
+}
+.statblock.pathfinder-2e-misc-layout .statblock-content > .column > :is(.statblock-item-container, .statblock-item-inline):has(.line.name) {
+  margin: 0;
+}
+.statblock.pathfinder-2e-misc-layout .statblock-content > .column > :is(.statblock-item-container, .statblock-item-inline) > :is(.property, .line:has(.property-name)) {
+  margin-left: 1em;
+}
+.statblock.pathfinder-2e-misc-layout .statblock-content > .column > :is(.statblock-item-container, .statblock-item-inline) > :is(.property, .line) .property-name {
+  margin-left: -1em;
+}
+.statblock.pathfinder-2e-misc-layout .statblock-content > .column > .statblock-item-container:has(.tapered-rule) {
+  margin-block: 0.25rem;
+}
+.statblock.pathfinder-2e-misc-layout .statblock-content > .column > .statblock-item-inline:has(.name) + .statblock-item-container:has(.tapered-rule) {
+  margin-top: 0;
+}
+.statblock.pathfinder-2e-misc-layout .statblock-content > .column > .statblock-item-inline:has(.rare_01,
+.rare_02,
+.rare_03,
+.rare_04,
+.alignment,
+.size,
+.xp,
+.kingdom_xp,
+.trait_01,
+.trait_02,
+.trait_03,
+.trait_04,
+.trait_05,
+.trait_06,
+.trait_07) {
+  row-gap: var(--statblock-traits-gap);
+  margin-bottom: 0.5em;
+}
+
+.statblock.pathfinder-2e-quest-layout .statblock-content {
+  background-color: var(--statblock-background-color);
+  border: var(--statblock-border-size) var(--statblock-border-color) solid;
+  box-shadow: none;
+  color: var(--statblock-property-font-color);
+  display: flex;
+  font-family: var(--statblock-content-font);
+  font-size: var(--statblock-content-font-size);
+  margin: 0.5em 2px;
+  padding: 0.5em;
+  gap: 1rem;
+}
+.statblock.pathfinder-2e-quest-layout .statblock-content .statblock-detached {
+  position: absolute;
+  top: -9999px;
+}
+.statblock.pathfinder-2e-quest-layout .statblock-content .statblock-item-container {
+  margin: 0;
+  padding: 0;
+}
+.statblock.pathfinder-2e-quest-layout .statblock-content .statblock-item-inline {
+  align-content: flex-start;
+  align-items: baseline;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  margin: 0;
+  padding: 0;
+}
+.statblock.pathfinder-2e-quest-layout .statblock-content > .column {
+  width: var(--statblock-column-width);
+  /* Hazard Block Specific */
+}
+.statblock.pathfinder-2e-quest-layout .statblock-content > .column > :is(.statblock-item-container, .statblock-item-inline):has(.line, .property) {
+  margin-block: 0.25rem;
+}
+.statblock.pathfinder-2e-quest-layout .statblock-content > .column > :is(.statblock-item-container, .statblock-item-inline):has(.line, .property):last-child {
+  margin-bottom: 0;
+}
+.statblock.pathfinder-2e-quest-layout .statblock-content > .column > :is(.statblock-item-container, .statblock-item-inline):has(.line.name) {
+  margin: 0;
+}
+.statblock.pathfinder-2e-quest-layout .statblock-content > .column > :is(.statblock-item-container, .statblock-item-inline) > :is(.property, .line:has(.property-name)) {
+  margin-left: 1em;
+}
+.statblock.pathfinder-2e-quest-layout .statblock-content > .column > :is(.statblock-item-container, .statblock-item-inline) > :is(.property, .line) .property-name {
+  margin-left: -1em;
+}
+.statblock.pathfinder-2e-quest-layout .statblock-content > .column > .statblock-item-container:has(.tapered-rule) {
+  margin-block: 0.25rem;
+}
+.statblock.pathfinder-2e-quest-layout .statblock-content > .column > .statblock-item-inline:has(.name) + .statblock-item-container:has(.tapered-rule) {
+  margin-top: 0;
+}
+.statblock.pathfinder-2e-quest-layout .statblock-content > .column > .statblock-item-inline:has(.rare_01,
+.rare_02,
+.rare_03,
+.rare_04,
+.alignment,
+.size,
+.xp,
+.kingdom_xp,
+.trait_01,
+.trait_02,
+.trait_03,
+.trait_04,
+.trait_05,
+.trait_06,
+.trait_07) {
+  row-gap: var(--statblock-traits-gap);
+  margin-bottom: 0.5em;
+}
+
+.statblock.pathfinder-2e-settlement-layout .statblock-content {
+  background-color: var(--statblock-background-color);
+  border: var(--statblock-border-size) var(--statblock-border-color) solid;
+  box-shadow: none;
+  color: var(--statblock-property-font-color);
+  display: flex;
+  font-family: var(--statblock-content-font);
+  font-size: var(--statblock-content-font-size);
+  margin: 0.5em 2px;
+  padding: 0.5em;
+  gap: 1rem;
+}
+.statblock.pathfinder-2e-settlement-layout .statblock-content .statblock-detached {
+  position: absolute;
+  top: -9999px;
+}
+.statblock.pathfinder-2e-settlement-layout .statblock-content .statblock-item-container {
+  margin: 0;
+  padding: 0;
+}
+.statblock.pathfinder-2e-settlement-layout .statblock-content .statblock-item-inline {
+  align-content: flex-start;
+  align-items: baseline;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  margin: 0;
+  padding: 0;
+}
+.statblock.pathfinder-2e-settlement-layout .statblock-content > .column {
+  width: var(--statblock-column-width);
+  /* Hazard Block Specific */
+}
+.statblock.pathfinder-2e-settlement-layout .statblock-content > .column > :is(.statblock-item-container, .statblock-item-inline):has(.line, .property) {
+  margin-block: 0.25rem;
+}
+.statblock.pathfinder-2e-settlement-layout .statblock-content > .column > :is(.statblock-item-container, .statblock-item-inline):has(.line, .property):last-child {
+  margin-bottom: 0;
+}
+.statblock.pathfinder-2e-settlement-layout .statblock-content > .column > :is(.statblock-item-container, .statblock-item-inline):has(.line.name) {
+  margin: 0;
+}
+.statblock.pathfinder-2e-settlement-layout .statblock-content > .column > :is(.statblock-item-container, .statblock-item-inline) > :is(.property, .line:has(.property-name)) {
+  margin-left: 1em;
+}
+.statblock.pathfinder-2e-settlement-layout .statblock-content > .column > :is(.statblock-item-container, .statblock-item-inline) > :is(.property, .line) .property-name {
+  margin-left: -1em;
+}
+.statblock.pathfinder-2e-settlement-layout .statblock-content > .column > .statblock-item-container:has(.tapered-rule) {
+  margin-block: 0.25rem;
+}
+.statblock.pathfinder-2e-settlement-layout .statblock-content > .column > .statblock-item-inline:has(.name) + .statblock-item-container:has(.tapered-rule) {
+  margin-top: 0;
+}
+.statblock.pathfinder-2e-settlement-layout .statblock-content > .column > .statblock-item-inline:has(.rare_01,
+.rare_02,
+.rare_03,
+.rare_04,
+.alignment,
+.size,
+.xp,
+.kingdom_xp,
+.trait_01,
+.trait_02,
+.trait_03,
+.trait_04,
+.trait_05,
+.trait_06,
+.trait_07) {
+  row-gap: var(--statblock-traits-gap);
+  margin-bottom: 0.5em;
+}
+
+.statblock.basic-pathfinder-2e-layout .bar {
+  height: 1px;
+  background: rgb(51, 51, 51);
+  border: 1px solid rgb(51, 51, 51);
+  z-index: 1;
+  width: fit-content;
+}
+.statblock.basic-pathfinder-2e-layout div.tapered-rule {
+  width: auto;
+  margin: 0;
+  height: 1px;
+  background: rgb(51, 51, 51);
+  clip-path: unset !important;
+  -webkit-clip-path: unset;
+}
+
+.statblock.pathfinder-2e-action-layout .bar {
+  height: 1px;
+  background: rgb(51, 51, 51);
+  border: 1px solid rgb(51, 51, 51);
+  z-index: 1;
+  width: fit-content;
+}
+.statblock.pathfinder-2e-action-layout div.tapered-rule {
+  width: auto;
+  margin: 0;
+  height: 1px;
+  background: rgb(51, 51, 51);
+  clip-path: unset !important;
+  -webkit-clip-path: unset;
+}
+
+.statblock.pathfinder-2e-hazard-layout .bar {
+  height: 1px;
+  background: rgb(51, 51, 51);
+  border: 1px solid rgb(51, 51, 51);
+  z-index: 1;
+  width: fit-content;
+}
+.statblock.pathfinder-2e-hazard-layout div.tapered-rule {
+  width: auto;
+  margin: 0;
+  height: 1px;
+  background: rgb(51, 51, 51);
+  clip-path: unset !important;
+  -webkit-clip-path: unset;
+}
+
+.statblock.pathfinder-2e-influence-layout .bar {
+  height: 1px;
+  background: rgb(51, 51, 51);
+  border: 1px solid rgb(51, 51, 51);
+  z-index: 1;
+  width: fit-content;
+}
+.statblock.pathfinder-2e-influence-layout div.tapered-rule {
+  width: auto;
+  margin: 0;
+  height: 1px;
+  background: rgb(51, 51, 51);
+  clip-path: unset !important;
+  -webkit-clip-path: unset;
+}
+
+.statblock.pathfinder-2e-misc-layout .bar {
+  height: 1px;
+  background: rgb(51, 51, 51);
+  border: 1px solid rgb(51, 51, 51);
+  z-index: 1;
+  width: fit-content;
+}
+.statblock.pathfinder-2e-misc-layout div.tapered-rule {
+  width: auto;
+  margin: 0;
+  height: 1px;
+  background: rgb(51, 51, 51);
+  clip-path: unset !important;
+  -webkit-clip-path: unset;
+}
+
+.statblock.pathfinder-2e-quest-layout .bar {
+  height: 1px;
+  background: rgb(51, 51, 51);
+  border: 1px solid rgb(51, 51, 51);
+  z-index: 1;
+  width: fit-content;
+}
+.statblock.pathfinder-2e-quest-layout div.tapered-rule {
+  width: auto;
+  margin: 0;
+  height: 1px;
+  background: rgb(51, 51, 51);
+  clip-path: unset !important;
+  -webkit-clip-path: unset;
+}
+
+.statblock.pathfinder-2e-settlement-layout .bar {
+  height: 1px;
+  background: rgb(51, 51, 51);
+  border: 1px solid rgb(51, 51, 51);
+  z-index: 1;
+  width: fit-content;
+}
+.statblock.pathfinder-2e-settlement-layout div.tapered-rule {
+  width: auto;
+  margin: 0;
+  height: 1px;
+  background: rgb(51, 51, 51);
+  clip-path: unset !important;
+  -webkit-clip-path: unset;
+}
+
+.statblock.basic-pathfinder-2e-layout .flex-container {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}
+.statblock.basic-pathfinder-2e-layout .heading {
+  align-items: center;
+  color: var(--statblock-heading-font-color);
+  display: flex;
+  font-family: var(--statblock-heading-font);
+  font-size: 1.35em;
+  font-variant: small-caps;
+  font-weight: 700;
+  justify-content: space-between;
+  letter-spacing: 1px;
+  line-height: 1;
+  margin: 0;
+}
+.statblock.basic-pathfinder-2e-layout .section-header {
+  border: none;
+  color: var(--statblock-section-heading-font-color);
+  font-size: var(--statblock-section-heading-font-size);
+  font-variant: var(--statblock-section-heading-font-variant);
+  font-weight: var(--statblock-section-heading-font-weight);
+  letter-spacing: 1px;
+  margin-bottom: 0.3em;
+}
+.statblock.basic-pathfinder-2e-layout h3.section-header {
+  display: none;
+}
+.statblock.basic-pathfinder-2e-layout h3,
+.statblock.basic-pathfinder-2e-layout .markdown-rendered h3,
+.statblock.basic-pathfinder-2e-layout .HyperMD-header-3,
+.statblock.basic-pathfinder-2e-layout .inline-title[data-level="3"],
+.statblock.basic-pathfinder-2e-layout .HyperMD-list-line .cm-header-3 {
+  font-variant: petite-caps;
+  letter-spacing: 1px;
+  line-height: 1;
+  font-size: 1.25em;
+  color: var(--statblock-section-heading-font-color);
+}
+
+.statblock.pathfinder-2e-action-layout .flex-container {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}
+.statblock.pathfinder-2e-action-layout .heading {
+  align-items: center;
+  color: var(--statblock-heading-font-color);
+  display: flex;
+  font-family: var(--statblock-heading-font);
+  font-size: 1.35em;
+  font-variant: small-caps;
+  font-weight: 700;
+  justify-content: space-between;
+  letter-spacing: 1px;
+  line-height: 1;
+  margin: 0;
+}
+.statblock.pathfinder-2e-action-layout .section-header {
+  border: none;
+  color: var(--statblock-section-heading-font-color);
+  font-size: var(--statblock-section-heading-font-size);
+  font-variant: var(--statblock-section-heading-font-variant);
+  font-weight: var(--statblock-section-heading-font-weight);
+  letter-spacing: 1px;
+  margin-bottom: 0.3em;
+}
+.statblock.pathfinder-2e-action-layout h3.section-header {
+  display: none;
+}
+.statblock.pathfinder-2e-action-layout h3,
+.statblock.pathfinder-2e-action-layout .markdown-rendered h3,
+.statblock.pathfinder-2e-action-layout .HyperMD-header-3,
+.statblock.pathfinder-2e-action-layout .inline-title[data-level="3"],
+.statblock.pathfinder-2e-action-layout .HyperMD-list-line .cm-header-3 {
+  font-variant: petite-caps;
+  letter-spacing: 1px;
+  line-height: 1;
+  font-size: 1.25em;
+  color: var(--statblock-section-heading-font-color);
+}
+
+.statblock.pathfinder-2e-hazard-layout .flex-container {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}
+.statblock.pathfinder-2e-hazard-layout .heading {
+  align-items: center;
+  color: var(--statblock-heading-font-color);
+  display: flex;
+  font-family: var(--statblock-heading-font);
+  font-size: 1.35em;
+  font-variant: small-caps;
+  font-weight: 700;
+  justify-content: space-between;
+  letter-spacing: 1px;
+  line-height: 1;
+  margin: 0;
+}
+.statblock.pathfinder-2e-hazard-layout .section-header {
+  border: none;
+  color: var(--statblock-section-heading-font-color);
+  font-size: var(--statblock-section-heading-font-size);
+  font-variant: var(--statblock-section-heading-font-variant);
+  font-weight: var(--statblock-section-heading-font-weight);
+  letter-spacing: 1px;
+  margin-bottom: 0.3em;
+}
+.statblock.pathfinder-2e-hazard-layout h3.section-header {
+  display: none;
+}
+.statblock.pathfinder-2e-hazard-layout h3,
+.statblock.pathfinder-2e-hazard-layout .markdown-rendered h3,
+.statblock.pathfinder-2e-hazard-layout .HyperMD-header-3,
+.statblock.pathfinder-2e-hazard-layout .inline-title[data-level="3"],
+.statblock.pathfinder-2e-hazard-layout .HyperMD-list-line .cm-header-3 {
+  font-variant: petite-caps;
+  letter-spacing: 1px;
+  line-height: 1;
+  font-size: 1.25em;
+  color: var(--statblock-section-heading-font-color);
+}
+
+.statblock.pathfinder-2e-influence-layout .flex-container {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}
+.statblock.pathfinder-2e-influence-layout .heading {
+  align-items: center;
+  color: var(--statblock-heading-font-color);
+  display: flex;
+  font-family: var(--statblock-heading-font);
+  font-size: 1.35em;
+  font-variant: small-caps;
+  font-weight: 700;
+  justify-content: space-between;
+  letter-spacing: 1px;
+  line-height: 1;
+  margin: 0;
+}
+.statblock.pathfinder-2e-influence-layout .section-header {
+  border: none;
+  color: var(--statblock-section-heading-font-color);
+  font-size: var(--statblock-section-heading-font-size);
+  font-variant: var(--statblock-section-heading-font-variant);
+  font-weight: var(--statblock-section-heading-font-weight);
+  letter-spacing: 1px;
+  margin-bottom: 0.3em;
+}
+.statblock.pathfinder-2e-influence-layout h3.section-header {
+  display: none;
+}
+.statblock.pathfinder-2e-influence-layout h3,
+.statblock.pathfinder-2e-influence-layout .markdown-rendered h3,
+.statblock.pathfinder-2e-influence-layout .HyperMD-header-3,
+.statblock.pathfinder-2e-influence-layout .inline-title[data-level="3"],
+.statblock.pathfinder-2e-influence-layout .HyperMD-list-line .cm-header-3 {
+  font-variant: petite-caps;
+  letter-spacing: 1px;
+  line-height: 1;
+  font-size: 1.25em;
+  color: var(--statblock-section-heading-font-color);
+}
+
+.statblock.pathfinder-2e-misc-layout .flex-container {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}
+.statblock.pathfinder-2e-misc-layout .heading {
+  align-items: center;
+  color: var(--statblock-heading-font-color);
+  display: flex;
+  font-family: var(--statblock-heading-font);
+  font-size: 1.35em;
+  font-variant: small-caps;
+  font-weight: 700;
+  justify-content: space-between;
+  letter-spacing: 1px;
+  line-height: 1;
+  margin: 0;
+}
+.statblock.pathfinder-2e-misc-layout .section-header {
+  border: none;
+  color: var(--statblock-section-heading-font-color);
+  font-size: var(--statblock-section-heading-font-size);
+  font-variant: var(--statblock-section-heading-font-variant);
+  font-weight: var(--statblock-section-heading-font-weight);
+  letter-spacing: 1px;
+  margin-bottom: 0.3em;
+}
+.statblock.pathfinder-2e-misc-layout h3.section-header {
+  display: none;
+}
+.statblock.pathfinder-2e-misc-layout h3,
+.statblock.pathfinder-2e-misc-layout .markdown-rendered h3,
+.statblock.pathfinder-2e-misc-layout .HyperMD-header-3,
+.statblock.pathfinder-2e-misc-layout .inline-title[data-level="3"],
+.statblock.pathfinder-2e-misc-layout .HyperMD-list-line .cm-header-3 {
+  font-variant: petite-caps;
+  letter-spacing: 1px;
+  line-height: 1;
+  font-size: 1.25em;
+  color: var(--statblock-section-heading-font-color);
+}
+
+.statblock.pathfinder-2e-quest-layout .flex-container {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}
+.statblock.pathfinder-2e-quest-layout .heading {
+  align-items: center;
+  color: var(--statblock-heading-font-color);
+  display: flex;
+  font-family: var(--statblock-heading-font);
+  font-size: 1.35em;
+  font-variant: small-caps;
+  font-weight: 700;
+  justify-content: space-between;
+  letter-spacing: 1px;
+  line-height: 1;
+  margin: 0;
+}
+.statblock.pathfinder-2e-quest-layout .section-header {
+  border: none;
+  color: var(--statblock-section-heading-font-color);
+  font-size: var(--statblock-section-heading-font-size);
+  font-variant: var(--statblock-section-heading-font-variant);
+  font-weight: var(--statblock-section-heading-font-weight);
+  letter-spacing: 1px;
+  margin-bottom: 0.3em;
+}
+.statblock.pathfinder-2e-quest-layout h3.section-header {
+  display: none;
+}
+.statblock.pathfinder-2e-quest-layout h3,
+.statblock.pathfinder-2e-quest-layout .markdown-rendered h3,
+.statblock.pathfinder-2e-quest-layout .HyperMD-header-3,
+.statblock.pathfinder-2e-quest-layout .inline-title[data-level="3"],
+.statblock.pathfinder-2e-quest-layout .HyperMD-list-line .cm-header-3 {
+  font-variant: petite-caps;
+  letter-spacing: 1px;
+  line-height: 1;
+  font-size: 1.25em;
+  color: var(--statblock-section-heading-font-color);
+}
+
+.statblock.pathfinder-2e-settlement-layout .flex-container {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}
+.statblock.pathfinder-2e-settlement-layout .heading {
+  align-items: center;
+  color: var(--statblock-heading-font-color);
+  display: flex;
+  font-family: var(--statblock-heading-font);
+  font-size: 1.35em;
+  font-variant: small-caps;
+  font-weight: 700;
+  justify-content: space-between;
+  letter-spacing: 1px;
+  line-height: 1;
+  margin: 0;
+}
+.statblock.pathfinder-2e-settlement-layout .section-header {
+  border: none;
+  color: var(--statblock-section-heading-font-color);
+  font-size: var(--statblock-section-heading-font-size);
+  font-variant: var(--statblock-section-heading-font-variant);
+  font-weight: var(--statblock-section-heading-font-weight);
+  letter-spacing: 1px;
+  margin-bottom: 0.3em;
+}
+.statblock.pathfinder-2e-settlement-layout h3.section-header {
+  display: none;
+}
+.statblock.pathfinder-2e-settlement-layout h3,
+.statblock.pathfinder-2e-settlement-layout .markdown-rendered h3,
+.statblock.pathfinder-2e-settlement-layout .HyperMD-header-3,
+.statblock.pathfinder-2e-settlement-layout .inline-title[data-level="3"],
+.statblock.pathfinder-2e-settlement-layout .HyperMD-list-line .cm-header-3 {
+  font-variant: petite-caps;
+  letter-spacing: 1px;
+  line-height: 1;
+  font-size: 1.25em;
+  color: var(--statblock-section-heading-font-color);
+}
+
+.statblock.basic-pathfinder-2e-layout a,
+.statblock.basic-pathfinder-2e-layout a:-webkit-any-link,
+.statblock.basic-pathfinder-2e-layout a.internal-link {
+  color: rgb(61, 102, 142);
+  font-weight: var(--statblock-property-name-font-weight);
+  text-decoration: none;
+}
+.statblock.basic-pathfinder-2e-layout b,
+.statblock.basic-pathfinder-2e-layout strong,
+.statblock.basic-pathfinder-2e-layout .cm-strong {
+  font-weight: var(--statblock-property-name-font-weight);
+  color: var(--statblock-property-name-font-color);
+}
+.statblock.basic-pathfinder-2e-layout i,
+.statblock.basic-pathfinder-2e-layout em,
+.statblock.basic-pathfinder-2e-layout .cm-em {
+  font-style: italic;
+  color: rgb(77, 27, 105);
+  font-weight: 500;
+}
+.statblock.basic-pathfinder-2e-layout ul {
+  /* Corrects the UL/LI Coloration */
+  display: block;
+  list-style-type: disc;
+  margin-block-start: 1em;
+  margin-block-end: 1em;
+  margin-inline-start: 0;
+  margin-inline-end: 0;
+  padding-inline-start: 40px;
+}
+.statblock.basic-pathfinder-2e-layout .markdown-rendered ul,
+.statblock.basic-pathfinder-2e-layout .markdown-rendered ol {
+  padding-inline-start: 2em;
+}
+.statblock.basic-pathfinder-2e-layout li {
+  color: var(--statblock-content-font);
+  display: list-item;
+  text-align: -webkit-match-parent;
+}
+.statblock.basic-pathfinder-2e-layout .markdown-source-view ol > li,
+.statblock.basic-pathfinder-2e-layout .markdown-source-view ul > li,
+.statblock.basic-pathfinder-2e-layout .markdown-preview-view ol > li,
+.statblock.basic-pathfinder-2e-layout .markdown-preview-view ul > li,
+.statblock.basic-pathfinder-2e-layout .markdown-rendered ul > li,
+.statblock.basic-pathfinder-2e-layout .mod-cm6 .HyperMD-list-line.cm-line {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+.statblock.basic-pathfinder-2e-layout ol > li::marker,
+.statblock.basic-pathfinder-2e-layout ul > li::marker,
+.statblock.basic-pathfinder-2e-layout .cm-s-obsidian .cm-formatting-list {
+  color: var(--statblock-property-name-font-color);
+}
+.statblock.basic-pathfinder-2e-layout ::marker {
+  unicode-bidi: isolate;
+  font-variant-numeric: tabular-nums;
+  text-transform: none;
+  text-indent: 0;
+  text-align: start;
+  text-align-last: start;
+}
+
+.statblock.pathfinder-2e-action-layout a,
+.statblock.pathfinder-2e-action-layout a:-webkit-any-link,
+.statblock.pathfinder-2e-action-layout a.internal-link {
+  color: rgb(61, 102, 142);
+  font-weight: var(--statblock-property-name-font-weight);
+  text-decoration: none;
+}
+.statblock.pathfinder-2e-action-layout b,
+.statblock.pathfinder-2e-action-layout strong,
+.statblock.pathfinder-2e-action-layout .cm-strong {
+  font-weight: var(--statblock-property-name-font-weight);
+  color: var(--statblock-property-name-font-color);
+}
+.statblock.pathfinder-2e-action-layout i,
+.statblock.pathfinder-2e-action-layout em,
+.statblock.pathfinder-2e-action-layout .cm-em {
+  font-style: italic;
+  color: rgb(77, 27, 105);
+  font-weight: 500;
+}
+.statblock.pathfinder-2e-action-layout ul {
+  /* Corrects the UL/LI Coloration */
+  display: block;
+  list-style-type: disc;
+  margin-block-start: 1em;
+  margin-block-end: 1em;
+  margin-inline-start: 0;
+  margin-inline-end: 0;
+  padding-inline-start: 40px;
+}
+.statblock.pathfinder-2e-action-layout .markdown-rendered ul,
+.statblock.pathfinder-2e-action-layout .markdown-rendered ol {
+  padding-inline-start: 2em;
+}
+.statblock.pathfinder-2e-action-layout li {
+  color: var(--statblock-content-font);
+  display: list-item;
+  text-align: -webkit-match-parent;
+}
+.statblock.pathfinder-2e-action-layout .markdown-source-view ol > li,
+.statblock.pathfinder-2e-action-layout .markdown-source-view ul > li,
+.statblock.pathfinder-2e-action-layout .markdown-preview-view ol > li,
+.statblock.pathfinder-2e-action-layout .markdown-preview-view ul > li,
+.statblock.pathfinder-2e-action-layout .markdown-rendered ul > li,
+.statblock.pathfinder-2e-action-layout .mod-cm6 .HyperMD-list-line.cm-line {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+.statblock.pathfinder-2e-action-layout ol > li::marker,
+.statblock.pathfinder-2e-action-layout ul > li::marker,
+.statblock.pathfinder-2e-action-layout .cm-s-obsidian .cm-formatting-list {
+  color: var(--statblock-property-name-font-color);
+}
+.statblock.pathfinder-2e-action-layout ::marker {
+  unicode-bidi: isolate;
+  font-variant-numeric: tabular-nums;
+  text-transform: none;
+  text-indent: 0;
+  text-align: start;
+  text-align-last: start;
+}
+
+.statblock.pathfinder-2e-hazard-layout a,
+.statblock.pathfinder-2e-hazard-layout a:-webkit-any-link,
+.statblock.pathfinder-2e-hazard-layout a.internal-link {
+  color: rgb(61, 102, 142);
+  font-weight: var(--statblock-property-name-font-weight);
+  text-decoration: none;
+}
+.statblock.pathfinder-2e-hazard-layout b,
+.statblock.pathfinder-2e-hazard-layout strong,
+.statblock.pathfinder-2e-hazard-layout .cm-strong {
+  font-weight: var(--statblock-property-name-font-weight);
+  color: var(--statblock-property-name-font-color);
+}
+.statblock.pathfinder-2e-hazard-layout i,
+.statblock.pathfinder-2e-hazard-layout em,
+.statblock.pathfinder-2e-hazard-layout .cm-em {
+  font-style: italic;
+  color: rgb(77, 27, 105);
+  font-weight: 500;
+}
+.statblock.pathfinder-2e-hazard-layout ul {
+  /* Corrects the UL/LI Coloration */
+  display: block;
+  list-style-type: disc;
+  margin-block-start: 1em;
+  margin-block-end: 1em;
+  margin-inline-start: 0;
+  margin-inline-end: 0;
+  padding-inline-start: 40px;
+}
+.statblock.pathfinder-2e-hazard-layout .markdown-rendered ul,
+.statblock.pathfinder-2e-hazard-layout .markdown-rendered ol {
+  padding-inline-start: 2em;
+}
+.statblock.pathfinder-2e-hazard-layout li {
+  color: var(--statblock-content-font);
+  display: list-item;
+  text-align: -webkit-match-parent;
+}
+.statblock.pathfinder-2e-hazard-layout .markdown-source-view ol > li,
+.statblock.pathfinder-2e-hazard-layout .markdown-source-view ul > li,
+.statblock.pathfinder-2e-hazard-layout .markdown-preview-view ol > li,
+.statblock.pathfinder-2e-hazard-layout .markdown-preview-view ul > li,
+.statblock.pathfinder-2e-hazard-layout .markdown-rendered ul > li,
+.statblock.pathfinder-2e-hazard-layout .mod-cm6 .HyperMD-list-line.cm-line {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+.statblock.pathfinder-2e-hazard-layout ol > li::marker,
+.statblock.pathfinder-2e-hazard-layout ul > li::marker,
+.statblock.pathfinder-2e-hazard-layout .cm-s-obsidian .cm-formatting-list {
+  color: var(--statblock-property-name-font-color);
+}
+.statblock.pathfinder-2e-hazard-layout ::marker {
+  unicode-bidi: isolate;
+  font-variant-numeric: tabular-nums;
+  text-transform: none;
+  text-indent: 0;
+  text-align: start;
+  text-align-last: start;
+}
+
+.statblock.pathfinder-2e-influence-layout a,
+.statblock.pathfinder-2e-influence-layout a:-webkit-any-link,
+.statblock.pathfinder-2e-influence-layout a.internal-link {
+  color: rgb(61, 102, 142);
+  font-weight: var(--statblock-property-name-font-weight);
+  text-decoration: none;
+}
+.statblock.pathfinder-2e-influence-layout b,
+.statblock.pathfinder-2e-influence-layout strong,
+.statblock.pathfinder-2e-influence-layout .cm-strong {
+  font-weight: var(--statblock-property-name-font-weight);
+  color: var(--statblock-property-name-font-color);
+}
+.statblock.pathfinder-2e-influence-layout i,
+.statblock.pathfinder-2e-influence-layout em,
+.statblock.pathfinder-2e-influence-layout .cm-em {
+  font-style: italic;
+  color: rgb(77, 27, 105);
+  font-weight: 500;
+}
+.statblock.pathfinder-2e-influence-layout ul {
+  /* Corrects the UL/LI Coloration */
+  display: block;
+  list-style-type: disc;
+  margin-block-start: 1em;
+  margin-block-end: 1em;
+  margin-inline-start: 0;
+  margin-inline-end: 0;
+  padding-inline-start: 40px;
+}
+.statblock.pathfinder-2e-influence-layout .markdown-rendered ul,
+.statblock.pathfinder-2e-influence-layout .markdown-rendered ol {
+  padding-inline-start: 2em;
+}
+.statblock.pathfinder-2e-influence-layout li {
+  color: var(--statblock-content-font);
+  display: list-item;
+  text-align: -webkit-match-parent;
+}
+.statblock.pathfinder-2e-influence-layout .markdown-source-view ol > li,
+.statblock.pathfinder-2e-influence-layout .markdown-source-view ul > li,
+.statblock.pathfinder-2e-influence-layout .markdown-preview-view ol > li,
+.statblock.pathfinder-2e-influence-layout .markdown-preview-view ul > li,
+.statblock.pathfinder-2e-influence-layout .markdown-rendered ul > li,
+.statblock.pathfinder-2e-influence-layout .mod-cm6 .HyperMD-list-line.cm-line {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+.statblock.pathfinder-2e-influence-layout ol > li::marker,
+.statblock.pathfinder-2e-influence-layout ul > li::marker,
+.statblock.pathfinder-2e-influence-layout .cm-s-obsidian .cm-formatting-list {
+  color: var(--statblock-property-name-font-color);
+}
+.statblock.pathfinder-2e-influence-layout ::marker {
+  unicode-bidi: isolate;
+  font-variant-numeric: tabular-nums;
+  text-transform: none;
+  text-indent: 0;
+  text-align: start;
+  text-align-last: start;
+}
+
+.statblock.pathfinder-2e-misc-layout a,
+.statblock.pathfinder-2e-misc-layout a:-webkit-any-link,
+.statblock.pathfinder-2e-misc-layout a.internal-link {
+  color: rgb(61, 102, 142);
+  font-weight: var(--statblock-property-name-font-weight);
+  text-decoration: none;
+}
+.statblock.pathfinder-2e-misc-layout b,
+.statblock.pathfinder-2e-misc-layout strong,
+.statblock.pathfinder-2e-misc-layout .cm-strong {
+  font-weight: var(--statblock-property-name-font-weight);
+  color: var(--statblock-property-name-font-color);
+}
+.statblock.pathfinder-2e-misc-layout i,
+.statblock.pathfinder-2e-misc-layout em,
+.statblock.pathfinder-2e-misc-layout .cm-em {
+  font-style: italic;
+  color: rgb(77, 27, 105);
+  font-weight: 500;
+}
+.statblock.pathfinder-2e-misc-layout ul {
+  /* Corrects the UL/LI Coloration */
+  display: block;
+  list-style-type: disc;
+  margin-block-start: 1em;
+  margin-block-end: 1em;
+  margin-inline-start: 0;
+  margin-inline-end: 0;
+  padding-inline-start: 40px;
+}
+.statblock.pathfinder-2e-misc-layout .markdown-rendered ul,
+.statblock.pathfinder-2e-misc-layout .markdown-rendered ol {
+  padding-inline-start: 2em;
+}
+.statblock.pathfinder-2e-misc-layout li {
+  color: var(--statblock-content-font);
+  display: list-item;
+  text-align: -webkit-match-parent;
+}
+.statblock.pathfinder-2e-misc-layout .markdown-source-view ol > li,
+.statblock.pathfinder-2e-misc-layout .markdown-source-view ul > li,
+.statblock.pathfinder-2e-misc-layout .markdown-preview-view ol > li,
+.statblock.pathfinder-2e-misc-layout .markdown-preview-view ul > li,
+.statblock.pathfinder-2e-misc-layout .markdown-rendered ul > li,
+.statblock.pathfinder-2e-misc-layout .mod-cm6 .HyperMD-list-line.cm-line {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+.statblock.pathfinder-2e-misc-layout ol > li::marker,
+.statblock.pathfinder-2e-misc-layout ul > li::marker,
+.statblock.pathfinder-2e-misc-layout .cm-s-obsidian .cm-formatting-list {
+  color: var(--statblock-property-name-font-color);
+}
+.statblock.pathfinder-2e-misc-layout ::marker {
+  unicode-bidi: isolate;
+  font-variant-numeric: tabular-nums;
+  text-transform: none;
+  text-indent: 0;
+  text-align: start;
+  text-align-last: start;
+}
+
+.statblock.pathfinder-2e-quest-layout a,
+.statblock.pathfinder-2e-quest-layout a:-webkit-any-link,
+.statblock.pathfinder-2e-quest-layout a.internal-link {
+  color: rgb(61, 102, 142);
+  font-weight: var(--statblock-property-name-font-weight);
+  text-decoration: none;
+}
+.statblock.pathfinder-2e-quest-layout b,
+.statblock.pathfinder-2e-quest-layout strong,
+.statblock.pathfinder-2e-quest-layout .cm-strong {
+  font-weight: var(--statblock-property-name-font-weight);
+  color: var(--statblock-property-name-font-color);
+}
+.statblock.pathfinder-2e-quest-layout i,
+.statblock.pathfinder-2e-quest-layout em,
+.statblock.pathfinder-2e-quest-layout .cm-em {
+  font-style: italic;
+  color: rgb(77, 27, 105);
+  font-weight: 500;
+}
+.statblock.pathfinder-2e-quest-layout ul {
+  /* Corrects the UL/LI Coloration */
+  display: block;
+  list-style-type: disc;
+  margin-block-start: 1em;
+  margin-block-end: 1em;
+  margin-inline-start: 0;
+  margin-inline-end: 0;
+  padding-inline-start: 40px;
+}
+.statblock.pathfinder-2e-quest-layout .markdown-rendered ul,
+.statblock.pathfinder-2e-quest-layout .markdown-rendered ol {
+  padding-inline-start: 2em;
+}
+.statblock.pathfinder-2e-quest-layout li {
+  color: var(--statblock-content-font);
+  display: list-item;
+  text-align: -webkit-match-parent;
+}
+.statblock.pathfinder-2e-quest-layout .markdown-source-view ol > li,
+.statblock.pathfinder-2e-quest-layout .markdown-source-view ul > li,
+.statblock.pathfinder-2e-quest-layout .markdown-preview-view ol > li,
+.statblock.pathfinder-2e-quest-layout .markdown-preview-view ul > li,
+.statblock.pathfinder-2e-quest-layout .markdown-rendered ul > li,
+.statblock.pathfinder-2e-quest-layout .mod-cm6 .HyperMD-list-line.cm-line {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+.statblock.pathfinder-2e-quest-layout ol > li::marker,
+.statblock.pathfinder-2e-quest-layout ul > li::marker,
+.statblock.pathfinder-2e-quest-layout .cm-s-obsidian .cm-formatting-list {
+  color: var(--statblock-property-name-font-color);
+}
+.statblock.pathfinder-2e-quest-layout ::marker {
+  unicode-bidi: isolate;
+  font-variant-numeric: tabular-nums;
+  text-transform: none;
+  text-indent: 0;
+  text-align: start;
+  text-align-last: start;
+}
+
+.statblock.pathfinder-2e-settlement-layout a,
+.statblock.pathfinder-2e-settlement-layout a:-webkit-any-link,
+.statblock.pathfinder-2e-settlement-layout a.internal-link {
+  color: rgb(61, 102, 142);
+  font-weight: var(--statblock-property-name-font-weight);
+  text-decoration: none;
+}
+.statblock.pathfinder-2e-settlement-layout b,
+.statblock.pathfinder-2e-settlement-layout strong,
+.statblock.pathfinder-2e-settlement-layout .cm-strong {
+  font-weight: var(--statblock-property-name-font-weight);
+  color: var(--statblock-property-name-font-color);
+}
+.statblock.pathfinder-2e-settlement-layout i,
+.statblock.pathfinder-2e-settlement-layout em,
+.statblock.pathfinder-2e-settlement-layout .cm-em {
+  font-style: italic;
+  color: rgb(77, 27, 105);
+  font-weight: 500;
+}
+.statblock.pathfinder-2e-settlement-layout ul {
+  /* Corrects the UL/LI Coloration */
+  display: block;
+  list-style-type: disc;
+  margin-block-start: 1em;
+  margin-block-end: 1em;
+  margin-inline-start: 0;
+  margin-inline-end: 0;
+  padding-inline-start: 40px;
+}
+.statblock.pathfinder-2e-settlement-layout .markdown-rendered ul,
+.statblock.pathfinder-2e-settlement-layout .markdown-rendered ol {
+  padding-inline-start: 2em;
+}
+.statblock.pathfinder-2e-settlement-layout li {
+  color: var(--statblock-content-font);
+  display: list-item;
+  text-align: -webkit-match-parent;
+}
+.statblock.pathfinder-2e-settlement-layout .markdown-source-view ol > li,
+.statblock.pathfinder-2e-settlement-layout .markdown-source-view ul > li,
+.statblock.pathfinder-2e-settlement-layout .markdown-preview-view ol > li,
+.statblock.pathfinder-2e-settlement-layout .markdown-preview-view ul > li,
+.statblock.pathfinder-2e-settlement-layout .markdown-rendered ul > li,
+.statblock.pathfinder-2e-settlement-layout .mod-cm6 .HyperMD-list-line.cm-line {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+.statblock.pathfinder-2e-settlement-layout ol > li::marker,
+.statblock.pathfinder-2e-settlement-layout ul > li::marker,
+.statblock.pathfinder-2e-settlement-layout .cm-s-obsidian .cm-formatting-list {
+  color: var(--statblock-property-name-font-color);
+}
+.statblock.pathfinder-2e-settlement-layout ::marker {
+  unicode-bidi: isolate;
+  font-variant-numeric: tabular-nums;
+  text-transform: none;
+  text-indent: 0;
+  text-align: start;
+  text-align-last: start;
+}
+
 .statblock.basic-pathfinder-2e-layout .line {
-    line-height: var(--statblock-property-line-height);
-    display: block;
-    color: var(--statblock-property-line-font-color);
+  line-height: var(--statblock-property-line-height);
+  display: block;
+  color: var(--statblock-property-font-color);
 }
 .statblock.basic-pathfinder-2e-layout .statblock-rendered-text-content {
-    color: var(--statblock-property-name-font-color);
-    font-weight: var(--statblock-property-name-font-weight);
+  color: var(--statblock-property-name-font-color);
+  font-weight: var(--statblock-property-name-font-weight);
 }
 .statblock.basic-pathfinder-2e-layout .statblock-markdown,
 .statblock.basic-pathfinder-2e-layout .property {
-    line-height: var(--statblock-property-line-height);
+  line-height: var(--statblock-property-line-height);
 }
-.statblock.basic-pathfinder-2e-layout div.tapered-rule {
-    width: auto;
-    margin: 0;
-    height: 1px;
-    background: var(--statblock-bar-color);
-    clip-path: unset !important;
-    -webkit-clip-path: unset;
+
+.statblock.pathfinder-2e-action-layout .line {
+  line-height: var(--statblock-property-line-height);
+  display: block;
+  color: var(--statblock-property-font-color);
 }
-.statblock.basic-pathfinder-2e-layout .flex-container {
-    align-items: center;
-    display: flex;
-    justify-content: space-between;
+.statblock.pathfinder-2e-action-layout .statblock-rendered-text-content {
+  color: var(--statblock-property-name-font-color);
+  font-weight: var(--statblock-property-name-font-weight);
 }
-.statblock.basic-pathfinder-2e-layout .heading {
-    align-items: center;
-    color: var(--statblock-heading-font-color);
-    display: flex;
-    font-family: var(--statblock-heading-font);
-    font-variant: var(--statblock-heading-font-variant);
-    font-weight: var(--statblock-heading-font-weight);
-    justify-content: space-between;
-    line-height: var(--statblock-heading-line-height);
-    letter-spacing: 1px;
-    margin: 0;
+.statblock.pathfinder-2e-action-layout .statblock-markdown,
+.statblock.pathfinder-2e-action-layout .property {
+  line-height: var(--statblock-property-line-height);
 }
-.statblock.basic-pathfinder-2e-layout h1.section-header {
-    border: none;
-    color: var(--statblock-section-heading-font-color);
-    font-size: var(--statblock-section-heading-font-size);
-    font-variant: var(--statblock-section-heading-font-variant);
-    font-weight: var(--statblock-section-heading-font-weight);
-    letter-spacing: 1px;
-    margin: 0;
-    margin-bottom: 0.3em;
-    break-inside: avoid-column;
-    break-after: avoid-column;
+
+.statblock.pathfinder-2e-hazard-layout .line {
+  line-height: var(--statblock-property-line-height);
+  display: block;
+  color: var(--statblock-property-font-color);
 }
-.statblock.basic-pathfinder-2e-layout h2.section-header {
-    border: none;
-    color: var(--statblock-section-heading-font-color);
-    font-size: var(--statblock-section-heading-font-size);
-    font-variant: var(--statblock-section-heading-font-variant);
-    font-weight: var(--statblock-section-heading-font-weight);
-    letter-spacing: 1px;
-    margin: 0;
-    margin-bottom: 0.3em;
-    break-inside: avoid-column;
-    break-after: avoid-column;
+.statblock.pathfinder-2e-hazard-layout .statblock-rendered-text-content {
+  color: var(--statblock-property-name-font-color);
+  font-weight: var(--statblock-property-name-font-weight);
 }
-.statblock.basic-pathfinder-2e-layout h3.section-header {
-    border: none;
-    color: var(--statblock-section-heading-font-color);
-    font-size: var(--statblock-section-heading-font-size);
-    font-variant: var(--statblock-section-heading-font-variant);
-    font-weight: var(--statblock-section-heading-font-weight);
-    letter-spacing: 1px;
-    margin: 0;
-    margin-bottom: 0;
-    break-inside: avoid-column;
-    break-after: avoid-column;
-    display: none;
+.statblock.pathfinder-2e-hazard-layout .statblock-markdown,
+.statblock.pathfinder-2e-hazard-layout .property {
+  line-height: var(--statblock-property-line-height);
 }
-.statblock.basic-pathfinder-2e-layout .spell-line .spells {
-    font-style: var(--statblock-spells-font-style);
+
+.statblock.pathfinder-2e-influence-layout .line {
+  line-height: var(--statblock-property-line-height);
+  display: block;
+  color: var(--statblock-property-font-color);
 }
-.statblock.basic-pathfinder-2e-layout .statblock-table-header {
-    font-weight: var(--statblock-table-header-font-weight);
+.statblock.pathfinder-2e-influence-layout .statblock-rendered-text-content {
+  color: var(--statblock-property-name-font-color);
+  font-weight: var(--statblock-property-name-font-weight);
 }
-.statblock.basic-pathfinder-2e-layout .table {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: center;
-    flex-wrap: wrap;
+.statblock.pathfinder-2e-influence-layout .statblock-markdown,
+.statblock.pathfinder-2e-influence-layout .property {
+  line-height: var(--statblock-property-line-height);
 }
-.statblock.basic-pathfinder-2e-layout .table-item {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    flex-flow: column nowrap;
+
+.statblock.pathfinder-2e-misc-layout .line {
+  line-height: var(--statblock-property-line-height);
+  display: block;
+  color: var(--statblock-property-font-color);
 }
+.statblock.pathfinder-2e-misc-layout .statblock-rendered-text-content {
+  color: var(--statblock-property-name-font-color);
+  font-weight: var(--statblock-property-name-font-weight);
+}
+.statblock.pathfinder-2e-misc-layout .statblock-markdown,
+.statblock.pathfinder-2e-misc-layout .property {
+  line-height: var(--statblock-property-line-height);
+}
+
+.statblock.pathfinder-2e-quest-layout .line {
+  line-height: var(--statblock-property-line-height);
+  display: block;
+  color: var(--statblock-property-font-color);
+}
+.statblock.pathfinder-2e-quest-layout .statblock-rendered-text-content {
+  color: var(--statblock-property-name-font-color);
+  font-weight: var(--statblock-property-name-font-weight);
+}
+.statblock.pathfinder-2e-quest-layout .statblock-markdown,
+.statblock.pathfinder-2e-quest-layout .property {
+  line-height: var(--statblock-property-line-height);
+}
+
+.statblock.pathfinder-2e-settlement-layout .line {
+  line-height: var(--statblock-property-line-height);
+  display: block;
+  color: var(--statblock-property-font-color);
+}
+.statblock.pathfinder-2e-settlement-layout .statblock-rendered-text-content {
+  color: var(--statblock-property-name-font-color);
+  font-weight: var(--statblock-property-name-font-weight);
+}
+.statblock.pathfinder-2e-settlement-layout .statblock-markdown,
+.statblock.pathfinder-2e-settlement-layout .property {
+  line-height: var(--statblock-property-line-height);
+}
+
+.statblock.basic-pathfinder-2e-layout .statblock-item-inline:has(.statblock-inline-item .name) {
+  /* Formatting of the statblock heading */
+  display: flex;
+  flex-direction: row;
+  margin-inline: 0.25em;
+  gap: 0.25em;
+  align-items: center;
+}
+.statblock.basic-pathfinder-2e-layout .statblock-item-inline:has(.statblock-inline-item .name) .statblock-inline-item.property-container:has(.name) {
+  flex: 1;
+}
+.statblock.basic-pathfinder-2e-layout .statblock-item-inline:has(.statblock-inline-item .name) .statblock-inline-item.property-container .name p,
+.statblock.basic-pathfinder-2e-layout .statblock-item-inline:has(.statblock-inline-item .name) .statblock-inline-item.property-container .level p {
+  align-self: flex-start;
+  font-size: 1.3em;
+  font-weight: 900;
+  line-height: 1.5em;
+  text-transform: uppercase;
+}
+.statblock.basic-pathfinder-2e-layout .statblock-item-inline:has(.statblock-inline-item .name) .statblock-inline-item.property-container .name span.property-name,
+.statblock.basic-pathfinder-2e-layout .statblock-item-inline:has(.statblock-inline-item .name) .statblock-inline-item.property-container .level span.property-name {
+  display: none;
+}
+.statblock.basic-pathfinder-2e-layout .statblock-item-inline:has(.statblock-inline-item .name) .pathfinder-2e-quest-icon {
+  display: block;
+  height: var(--statblock-header-image-height);
+  width: unset;
+  max-width: unset;
+  padding: var(--statblock-header-image-padding);
+}
+
+.statblock.pathfinder-2e-action-layout .statblock-item-inline:has(.statblock-inline-item .name) {
+  /* Formatting of the statblock heading */
+  display: flex;
+  flex-direction: row;
+  margin-inline: 0.25em;
+  gap: 0.25em;
+  align-items: center;
+}
+.statblock.pathfinder-2e-action-layout .statblock-item-inline:has(.statblock-inline-item .name) .statblock-inline-item.property-container:has(.name) {
+  flex: 1;
+}
+.statblock.pathfinder-2e-action-layout .statblock-item-inline:has(.statblock-inline-item .name) .statblock-inline-item.property-container .name p,
+.statblock.pathfinder-2e-action-layout .statblock-item-inline:has(.statblock-inline-item .name) .statblock-inline-item.property-container .level p {
+  align-self: flex-start;
+  font-size: 1.3em;
+  font-weight: 900;
+  line-height: 1.5em;
+  text-transform: uppercase;
+}
+.statblock.pathfinder-2e-action-layout .statblock-item-inline:has(.statblock-inline-item .name) .statblock-inline-item.property-container .name span.property-name,
+.statblock.pathfinder-2e-action-layout .statblock-item-inline:has(.statblock-inline-item .name) .statblock-inline-item.property-container .level span.property-name {
+  display: none;
+}
+.statblock.pathfinder-2e-action-layout .statblock-item-inline:has(.statblock-inline-item .name) .pathfinder-2e-quest-icon {
+  display: block;
+  height: var(--statblock-header-image-height);
+  width: unset;
+  max-width: unset;
+  padding: var(--statblock-header-image-padding);
+}
+
+.statblock.pathfinder-2e-hazard-layout .statblock-item-inline:has(.statblock-inline-item .name) {
+  /* Formatting of the statblock heading */
+  display: flex;
+  flex-direction: row;
+  margin-inline: 0.25em;
+  gap: 0.25em;
+  align-items: center;
+}
+.statblock.pathfinder-2e-hazard-layout .statblock-item-inline:has(.statblock-inline-item .name) .statblock-inline-item.property-container:has(.name) {
+  flex: 1;
+}
+.statblock.pathfinder-2e-hazard-layout .statblock-item-inline:has(.statblock-inline-item .name) .statblock-inline-item.property-container .name p,
+.statblock.pathfinder-2e-hazard-layout .statblock-item-inline:has(.statblock-inline-item .name) .statblock-inline-item.property-container .level p {
+  align-self: flex-start;
+  font-size: 1.3em;
+  font-weight: 900;
+  line-height: 1.5em;
+  text-transform: uppercase;
+}
+.statblock.pathfinder-2e-hazard-layout .statblock-item-inline:has(.statblock-inline-item .name) .statblock-inline-item.property-container .name span.property-name,
+.statblock.pathfinder-2e-hazard-layout .statblock-item-inline:has(.statblock-inline-item .name) .statblock-inline-item.property-container .level span.property-name {
+  display: none;
+}
+.statblock.pathfinder-2e-hazard-layout .statblock-item-inline:has(.statblock-inline-item .name) .pathfinder-2e-quest-icon {
+  display: block;
+  height: var(--statblock-header-image-height);
+  width: unset;
+  max-width: unset;
+  padding: var(--statblock-header-image-padding);
+}
+
+.statblock.pathfinder-2e-influence-layout .statblock-item-inline:has(.statblock-inline-item .name) {
+  /* Formatting of the statblock heading */
+  display: flex;
+  flex-direction: row;
+  margin-inline: 0.25em;
+  gap: 0.25em;
+  align-items: center;
+}
+.statblock.pathfinder-2e-influence-layout .statblock-item-inline:has(.statblock-inline-item .name) .statblock-inline-item.property-container:has(.name) {
+  flex: 1;
+}
+.statblock.pathfinder-2e-influence-layout .statblock-item-inline:has(.statblock-inline-item .name) .statblock-inline-item.property-container .name p,
+.statblock.pathfinder-2e-influence-layout .statblock-item-inline:has(.statblock-inline-item .name) .statblock-inline-item.property-container .level p {
+  align-self: flex-start;
+  font-size: 1.3em;
+  font-weight: 900;
+  line-height: 1.5em;
+  text-transform: uppercase;
+}
+.statblock.pathfinder-2e-influence-layout .statblock-item-inline:has(.statblock-inline-item .name) .statblock-inline-item.property-container .name span.property-name,
+.statblock.pathfinder-2e-influence-layout .statblock-item-inline:has(.statblock-inline-item .name) .statblock-inline-item.property-container .level span.property-name {
+  display: none;
+}
+.statblock.pathfinder-2e-influence-layout .statblock-item-inline:has(.statblock-inline-item .name) .pathfinder-2e-quest-icon {
+  display: block;
+  height: var(--statblock-header-image-height);
+  width: unset;
+  max-width: unset;
+  padding: var(--statblock-header-image-padding);
+}
+
+.statblock.pathfinder-2e-misc-layout .statblock-item-inline:has(.statblock-inline-item .name) {
+  /* Formatting of the statblock heading */
+  display: flex;
+  flex-direction: row;
+  margin-inline: 0.25em;
+  gap: 0.25em;
+  align-items: center;
+}
+.statblock.pathfinder-2e-misc-layout .statblock-item-inline:has(.statblock-inline-item .name) .statblock-inline-item.property-container:has(.name) {
+  flex: 1;
+}
+.statblock.pathfinder-2e-misc-layout .statblock-item-inline:has(.statblock-inline-item .name) .statblock-inline-item.property-container .name p,
+.statblock.pathfinder-2e-misc-layout .statblock-item-inline:has(.statblock-inline-item .name) .statblock-inline-item.property-container .level p {
+  align-self: flex-start;
+  font-size: 1.3em;
+  font-weight: 900;
+  line-height: 1.5em;
+  text-transform: uppercase;
+}
+.statblock.pathfinder-2e-misc-layout .statblock-item-inline:has(.statblock-inline-item .name) .statblock-inline-item.property-container .name span.property-name,
+.statblock.pathfinder-2e-misc-layout .statblock-item-inline:has(.statblock-inline-item .name) .statblock-inline-item.property-container .level span.property-name {
+  display: none;
+}
+.statblock.pathfinder-2e-misc-layout .statblock-item-inline:has(.statblock-inline-item .name) .pathfinder-2e-quest-icon {
+  display: block;
+  height: var(--statblock-header-image-height);
+  width: unset;
+  max-width: unset;
+  padding: var(--statblock-header-image-padding);
+}
+
+.statblock.pathfinder-2e-quest-layout .statblock-item-inline:has(.statblock-inline-item .name) {
+  /* Formatting of the statblock heading */
+  display: flex;
+  flex-direction: row;
+  margin-inline: 0.25em;
+  gap: 0.25em;
+  align-items: center;
+}
+.statblock.pathfinder-2e-quest-layout .statblock-item-inline:has(.statblock-inline-item .name) .statblock-inline-item.property-container:has(.name) {
+  flex: 1;
+}
+.statblock.pathfinder-2e-quest-layout .statblock-item-inline:has(.statblock-inline-item .name) .statblock-inline-item.property-container .name p,
+.statblock.pathfinder-2e-quest-layout .statblock-item-inline:has(.statblock-inline-item .name) .statblock-inline-item.property-container .level p {
+  align-self: flex-start;
+  font-size: 1.3em;
+  font-weight: 900;
+  line-height: 1.5em;
+  text-transform: uppercase;
+}
+.statblock.pathfinder-2e-quest-layout .statblock-item-inline:has(.statblock-inline-item .name) .statblock-inline-item.property-container .name span.property-name,
+.statblock.pathfinder-2e-quest-layout .statblock-item-inline:has(.statblock-inline-item .name) .statblock-inline-item.property-container .level span.property-name {
+  display: none;
+}
+.statblock.pathfinder-2e-quest-layout .statblock-item-inline:has(.statblock-inline-item .name) .pathfinder-2e-quest-icon {
+  display: block;
+  height: var(--statblock-header-image-height);
+  width: unset;
+  max-width: unset;
+  padding: var(--statblock-header-image-padding);
+}
+
+.statblock.pathfinder-2e-settlement-layout .statblock-item-inline:has(.statblock-inline-item .name) {
+  /* Formatting of the statblock heading */
+  display: flex;
+  flex-direction: row;
+  margin-inline: 0.25em;
+  gap: 0.25em;
+  align-items: center;
+}
+.statblock.pathfinder-2e-settlement-layout .statblock-item-inline:has(.statblock-inline-item .name) .statblock-inline-item.property-container:has(.name) {
+  flex: 1;
+}
+.statblock.pathfinder-2e-settlement-layout .statblock-item-inline:has(.statblock-inline-item .name) .statblock-inline-item.property-container .name p,
+.statblock.pathfinder-2e-settlement-layout .statblock-item-inline:has(.statblock-inline-item .name) .statblock-inline-item.property-container .level p {
+  align-self: flex-start;
+  font-size: 1.3em;
+  font-weight: 900;
+  line-height: 1.5em;
+  text-transform: uppercase;
+}
+.statblock.pathfinder-2e-settlement-layout .statblock-item-inline:has(.statblock-inline-item .name) .statblock-inline-item.property-container .name span.property-name,
+.statblock.pathfinder-2e-settlement-layout .statblock-item-inline:has(.statblock-inline-item .name) .statblock-inline-item.property-container .level span.property-name {
+  display: none;
+}
+.statblock.pathfinder-2e-settlement-layout .statblock-item-inline:has(.statblock-inline-item .name) .pathfinder-2e-quest-icon {
+  display: block;
+  height: var(--statblock-header-image-height);
+  width: unset;
+  max-width: unset;
+  padding: var(--statblock-header-image-padding);
+}
+
+.statblock.basic-pathfinder-2e-layout img {
+  display: inline;
+  position: relative;
+  border: none;
+  transform: rotateY(180deg);
+}
+.statblock.basic-pathfinder-2e-layout .image-container {
+  text-align: center;
+}
+.statblock.basic-pathfinder-2e-layout .token > a {
+  display: inline;
+}
+.statblock.basic-pathfinder-2e-layout .image {
+  width: var(--statblock-image-width);
+  height: var(--statblock-image-height);
+  display: inline;
+  max-height: fit-content;
+  max-width: fit-content;
+  transform: rotateY(180deg);
+}
+.statblock.basic-pathfinder-2e-layout .statblock-inline-item .image {
+  width: fit-content;
+  height: fit-content;
+}
+.statblock.basic-pathfinder-2e-layout .statblock-inline-item .image img {
+  border: none;
+  display: inline;
+  position: relative;
+  align-self: center;
+  object-fit: contain;
+  transform: rotateY(180deg);
+}
+.statblock.basic-pathfinder-2e-layout .statblock-inline-item .image .pointer {
+  cursor: pointer;
+}
+
+.statblock.pathfinder-2e-action-layout img {
+  display: inline;
+  position: relative;
+  border: none;
+  transform: rotateY(180deg);
+}
+.statblock.pathfinder-2e-action-layout .image-container {
+  text-align: center;
+}
+.statblock.pathfinder-2e-action-layout .token > a {
+  display: inline;
+}
+.statblock.pathfinder-2e-action-layout .image {
+  width: var(--statblock-image-width);
+  height: var(--statblock-image-height);
+  display: inline;
+  max-height: fit-content;
+  max-width: fit-content;
+  transform: rotateY(180deg);
+}
+.statblock.pathfinder-2e-action-layout .statblock-inline-item .image {
+  width: fit-content;
+  height: fit-content;
+}
+.statblock.pathfinder-2e-action-layout .statblock-inline-item .image img {
+  border: none;
+  display: inline;
+  position: relative;
+  align-self: center;
+  object-fit: contain;
+  transform: rotateY(180deg);
+}
+.statblock.pathfinder-2e-action-layout .statblock-inline-item .image .pointer {
+  cursor: pointer;
+}
+
+.statblock.pathfinder-2e-hazard-layout img {
+  display: inline;
+  position: relative;
+  border: none;
+  transform: rotateY(180deg);
+}
+.statblock.pathfinder-2e-hazard-layout .image-container {
+  text-align: center;
+}
+.statblock.pathfinder-2e-hazard-layout .token > a {
+  display: inline;
+}
+.statblock.pathfinder-2e-hazard-layout .image {
+  width: var(--statblock-image-width);
+  height: var(--statblock-image-height);
+  display: inline;
+  max-height: fit-content;
+  max-width: fit-content;
+  transform: rotateY(180deg);
+}
+.statblock.pathfinder-2e-hazard-layout .statblock-inline-item .image {
+  width: fit-content;
+  height: fit-content;
+}
+.statblock.pathfinder-2e-hazard-layout .statblock-inline-item .image img {
+  border: none;
+  display: inline;
+  position: relative;
+  align-self: center;
+  object-fit: contain;
+  transform: rotateY(180deg);
+}
+.statblock.pathfinder-2e-hazard-layout .statblock-inline-item .image .pointer {
+  cursor: pointer;
+}
+
+.statblock.pathfinder-2e-influence-layout img {
+  display: inline;
+  position: relative;
+  border: none;
+  transform: rotateY(180deg);
+}
+.statblock.pathfinder-2e-influence-layout .image-container {
+  text-align: center;
+}
+.statblock.pathfinder-2e-influence-layout .token > a {
+  display: inline;
+}
+.statblock.pathfinder-2e-influence-layout .image {
+  width: var(--statblock-image-width);
+  height: var(--statblock-image-height);
+  display: inline;
+  max-height: fit-content;
+  max-width: fit-content;
+  transform: rotateY(180deg);
+}
+.statblock.pathfinder-2e-influence-layout .statblock-inline-item .image {
+  width: fit-content;
+  height: fit-content;
+}
+.statblock.pathfinder-2e-influence-layout .statblock-inline-item .image img {
+  border: none;
+  display: inline;
+  position: relative;
+  align-self: center;
+  object-fit: contain;
+  transform: rotateY(180deg);
+}
+.statblock.pathfinder-2e-influence-layout .statblock-inline-item .image .pointer {
+  cursor: pointer;
+}
+
+.statblock.pathfinder-2e-misc-layout img {
+  display: inline;
+  position: relative;
+  border: none;
+  transform: rotateY(180deg);
+}
+.statblock.pathfinder-2e-misc-layout .image-container {
+  text-align: center;
+}
+.statblock.pathfinder-2e-misc-layout .token > a {
+  display: inline;
+}
+.statblock.pathfinder-2e-misc-layout .image {
+  width: var(--statblock-image-width);
+  height: var(--statblock-image-height);
+  display: inline;
+  max-height: fit-content;
+  max-width: fit-content;
+  transform: rotateY(180deg);
+}
+.statblock.pathfinder-2e-misc-layout .statblock-inline-item .image {
+  width: fit-content;
+  height: fit-content;
+}
+.statblock.pathfinder-2e-misc-layout .statblock-inline-item .image img {
+  border: none;
+  display: inline;
+  position: relative;
+  align-self: center;
+  object-fit: contain;
+  transform: rotateY(180deg);
+}
+.statblock.pathfinder-2e-misc-layout .statblock-inline-item .image .pointer {
+  cursor: pointer;
+}
+
+.statblock.pathfinder-2e-quest-layout img {
+  display: inline;
+  position: relative;
+  border: none;
+  transform: rotateY(180deg);
+}
+.statblock.pathfinder-2e-quest-layout .image-container {
+  text-align: center;
+}
+.statblock.pathfinder-2e-quest-layout .token > a {
+  display: inline;
+}
+.statblock.pathfinder-2e-quest-layout .image {
+  width: var(--statblock-image-width);
+  height: var(--statblock-image-height);
+  display: inline;
+  max-height: fit-content;
+  max-width: fit-content;
+  transform: rotateY(180deg);
+}
+.statblock.pathfinder-2e-quest-layout .statblock-inline-item .image {
+  width: fit-content;
+  height: fit-content;
+}
+.statblock.pathfinder-2e-quest-layout .statblock-inline-item .image img {
+  border: none;
+  display: inline;
+  position: relative;
+  align-self: center;
+  object-fit: contain;
+  transform: rotateY(180deg);
+}
+.statblock.pathfinder-2e-quest-layout .statblock-inline-item .image .pointer {
+  cursor: pointer;
+}
+
+.statblock.pathfinder-2e-settlement-layout img {
+  display: inline;
+  position: relative;
+  border: none;
+  transform: rotateY(180deg);
+}
+.statblock.pathfinder-2e-settlement-layout .image-container {
+  text-align: center;
+}
+.statblock.pathfinder-2e-settlement-layout .token > a {
+  display: inline;
+}
+.statblock.pathfinder-2e-settlement-layout .image {
+  width: var(--statblock-image-width);
+  height: var(--statblock-image-height);
+  display: inline;
+  max-height: fit-content;
+  max-width: fit-content;
+  transform: rotateY(180deg);
+}
+.statblock.pathfinder-2e-settlement-layout .statblock-inline-item .image {
+  width: fit-content;
+  height: fit-content;
+}
+.statblock.pathfinder-2e-settlement-layout .statblock-inline-item .image img {
+  border: none;
+  display: inline;
+  position: relative;
+  align-self: center;
+  object-fit: contain;
+  transform: rotateY(180deg);
+}
+.statblock.pathfinder-2e-settlement-layout .statblock-inline-item .image .pointer {
+  cursor: pointer;
+}
+
 .statblock.basic-pathfinder-2e-layout .traits {
-    margin: 0 0.25em 0 0;
-    display: inline;
-    font-weight: var(--statblock-traits-font-weight) !important;
-    font-style: var(--statblock-traits-font-style) !important;
+  margin: 0 0.25em 0 0;
+  display: inline;
+  font-weight: 900 !important;
+  font-style: normal !important;
 }
 .statblock.basic-pathfinder-2e-layout .rare_01 {
-    background-color: var(--statblock-color-common) !important;
+  background-color: var(--statblock-color-common) !important;
+  /* common */
 }
 .statblock.basic-pathfinder-2e-layout .rare_02 {
-    background-color: var(--statblock-color-uncommon) !important;
+  background-color: var(--statblock-color-uncommon) !important;
+  /* uncommon */
 }
 .statblock.basic-pathfinder-2e-layout .rare_03 {
-    background-color: var(--statblock-color-rare) !important;
+  background-color: var(--statblock-color-rare) !important;
+  /* rare */
 }
 .statblock.basic-pathfinder-2e-layout .rare_04 {
-    background-color: var(--statblock-color-unique) !important;
+  background-color: var(--statblock-color-unique) !important;
+  /* unique */
 }
 .statblock.basic-pathfinder-2e-layout .alignment {
-    background-color: var(--statblock-color-alignment) !important;
+  background-color: var(--statblock-color-alignment) !important;
 }
 .statblock.basic-pathfinder-2e-layout .size {
-    background-color: var(--statblock-color-size) !important;
+  background-color: var(--statblock-color-size) !important;
 }
 .statblock.basic-pathfinder-2e-layout .xp,
 .statblock.basic-pathfinder-2e-layout .kingdom_xp,
@@ -660,7 +2662,7 @@ body.path2eblockset-theme-kingmaker .statblock.basic-pathfinder-2e-layoutset {
 .statblock.basic-pathfinder-2e-layout .trait_05,
 .statblock.basic-pathfinder-2e-layout .trait_06,
 .statblock.basic-pathfinder-2e-layout .trait_07 {
-    background-color: var(--statblock-color-trait) !important;
+  background-color: var(--statblock-color-trait) !important;
 }
 .statblock.basic-pathfinder-2e-layout .rare_01,
 .statblock.basic-pathfinder-2e-layout .rare_02,
@@ -677,16 +2679,16 @@ body.path2eblockset-theme-kingmaker .statblock.basic-pathfinder-2e-layoutset {
 .statblock.basic-pathfinder-2e-layout .trait_05,
 .statblock.basic-pathfinder-2e-layout .trait_06,
 .statblock.basic-pathfinder-2e-layout .trait_07 {
-    color: var(--statblock-traits-font-color) !important;
-    font-size: var(--statblock-traits-font-size);
-    font-style: var(--statblock-traits-font-style) !important;
-    font-weight: var(--statblock-traits-font-weight) !important;
-    letter-spacing: var(--statblock-traits-letter-spacing);
-    min-width: var(--statblock-traits-min-width);
-    margin: var(--statblock-traits-margins);
-    padding: var(--statblock-traits-padding);
-    text-align: var(--statblock-traits-text-align);
-    text-transform: var(--statblock-traits-text-transform);
+  color: rgb(255, 255, 255) !important;
+  font-size: 12px;
+  font-style: normal !important;
+  font-weight: 900 !important;
+  letter-spacing: 0.01em;
+  min-width: 4em;
+  margin: 0 var(--statblock-traits-gap) 0 0;
+  padding: 0.4em 1.1em 0.2em;
+  text-align: center;
+  text-transform: uppercase;
 }
 .statblock.basic-pathfinder-2e-layout .rare_01 span.property-name,
 .statblock.basic-pathfinder-2e-layout .rare_02 span.property-name,
@@ -703,3576 +2705,783 @@ body.path2eblockset-theme-kingmaker .statblock.basic-pathfinder-2e-layoutset {
 .statblock.basic-pathfinder-2e-layout .trait_05 span.property-name,
 .statblock.basic-pathfinder-2e-layout .trait_06 span.property-name,
 .statblock.basic-pathfinder-2e-layout .trait_07 span.property-name {
-    display: none;
+  display: none;
 }
-.statblock.basic-pathfinder-2e-layout h3,
-.statblock.basic-pathfinder-2e-layout .markdown-rendered h3,
-.statblock.basic-pathfinder-2e-layout .HyperMD-header-3,
-.statblock.basic-pathfinder-2e-layout .inline-title[data-level="3"],
-.statblock.basic-pathfinder-2e-layout .HyperMD-list-line .cm-header-3 {
-    font-variant: var(--statblock-h3-variant);
-    letter-spacing: var(--statblock-h3-letter-spacing);
-    line-height: var(--statblock-h3-line-height);
-    font-size: var(--statblock-h3-size);
-    color: var(--statblock-h3-color);
+
+.statblock.pathfinder-2e-action-layout .traits {
+  margin: 0 0.25em 0 0;
+  display: inline;
+  font-weight: 900 !important;
+  font-style: normal !important;
 }
-.statblock.basic-pathfinder-2e-layout a,
-.statblock.basic-pathfinder-2e-layout a:-webkit-any-link,
-.statblock.basic-pathfinder-2e-layout a.internal-link {
-    color: var(--statblock-hyperlink-color);
-    font-weight: bolder;
-    text-decoration: var(--statblock-hyperlink-text-decoration);
+.statblock.pathfinder-2e-action-layout .rare_01 {
+  background-color: var(--statblock-color-common) !important;
+  /* common */
 }
-.statblock.basic-pathfinder-2e-layout b,
-.statblock.basic-pathfinder-2e-layout strong,
-.statblock.basic-pathfinder-2e-layout .cm-strong {
-    font-weight: var(--statblock-property-name-font-weight);
-    color: var(--statblock-property-name-font-color);
+.statblock.pathfinder-2e-action-layout .rare_02 {
+  background-color: var(--statblock-color-uncommon) !important;
+  /* uncommon */
 }
-.statblock.basic-pathfinder-2e-layout i,
-.statblock.basic-pathfinder-2e-layout em,
-.statblock.basic-pathfinder-2e-layout .cm-em {
-    font-style: italic;
-    color: var(--statblock-italic-font-color);
-    font-weight: 500;
+.statblock.pathfinder-2e-action-layout .rare_03 {
+  background-color: var(--statblock-color-rare) !important;
+  /* rare */
 }
-.statblock.basic-pathfinder-2e-layout
-    .statblock-item-inline:has(.statblock-inline-item .name) {
-    display: flex;
-    flex-direction: row;
-    margin-inline: 0.25em;
-    gap: 0.25em;
+.statblock.pathfinder-2e-action-layout .rare_04 {
+  background-color: var(--statblock-color-unique) !important;
+  /* unique */
 }
-.statblock.basic-pathfinder-2e-layout
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item {
+.statblock.pathfinder-2e-action-layout .alignment {
+  background-color: var(--statblock-color-alignment) !important;
 }
-.statblock.basic-pathfinder-2e-layout
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item:has(.name) {
-    flex: 1;
+.statblock.pathfinder-2e-action-layout .size {
+  background-color: var(--statblock-color-size) !important;
 }
-.statblock.basic-pathfinder-2e-layout
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .name,
-.statblock.basic-pathfinder-2e-layout
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .level {
+.statblock.pathfinder-2e-action-layout .xp,
+.statblock.pathfinder-2e-action-layout .kingdom_xp,
+.statblock.pathfinder-2e-action-layout .trait_01,
+.statblock.pathfinder-2e-action-layout .trait_02,
+.statblock.pathfinder-2e-action-layout .trait_03,
+.statblock.pathfinder-2e-action-layout .trait_04,
+.statblock.pathfinder-2e-action-layout .trait_05,
+.statblock.pathfinder-2e-action-layout .trait_06,
+.statblock.pathfinder-2e-action-layout .trait_07 {
+  background-color: var(--statblock-color-trait) !important;
 }
-.statblock.basic-pathfinder-2e-layout
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .name
-    p,
-.statblock.basic-pathfinder-2e-layout
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .level
-    p {
-    align-self: flex-start;
-    font-size: 1.2em;
-    font-weight: 900;
-    text-transform: uppercase;
+.statblock.pathfinder-2e-action-layout .rare_01,
+.statblock.pathfinder-2e-action-layout .rare_02,
+.statblock.pathfinder-2e-action-layout .rare_03,
+.statblock.pathfinder-2e-action-layout .rare_04,
+.statblock.pathfinder-2e-action-layout .alignment,
+.statblock.pathfinder-2e-action-layout .size,
+.statblock.pathfinder-2e-action-layout .xp,
+.statblock.pathfinder-2e-action-layout .kingdom_xp,
+.statblock.pathfinder-2e-action-layout .trait_01,
+.statblock.pathfinder-2e-action-layout .trait_02,
+.statblock.pathfinder-2e-action-layout .trait_03,
+.statblock.pathfinder-2e-action-layout .trait_04,
+.statblock.pathfinder-2e-action-layout .trait_05,
+.statblock.pathfinder-2e-action-layout .trait_06,
+.statblock.pathfinder-2e-action-layout .trait_07 {
+  color: rgb(255, 255, 255) !important;
+  font-size: 12px;
+  font-style: normal !important;
+  font-weight: 900 !important;
+  letter-spacing: 0.01em;
+  min-width: 4em;
+  margin: 0 var(--statblock-traits-gap) 0 0;
+  padding: 0.4em 1.1em 0.2em;
+  text-align: center;
+  text-transform: uppercase;
 }
-.statblock.basic-pathfinder-2e-layout
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .name
-    span.property-name,
-.statblock.basic-pathfinder-2e-layout
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .level
-    span.property-name {
-    display: none;
+.statblock.pathfinder-2e-action-layout .rare_01 span.property-name,
+.statblock.pathfinder-2e-action-layout .rare_02 span.property-name,
+.statblock.pathfinder-2e-action-layout .rare_03 span.property-name,
+.statblock.pathfinder-2e-action-layout .rare_04 span.property-name,
+.statblock.pathfinder-2e-action-layout .alignment span.property-name,
+.statblock.pathfinder-2e-action-layout .size span.property-name,
+.statblock.pathfinder-2e-action-layout .xp span.property-name,
+.statblock.pathfinder-2e-action-layout .kingdom_xp span.property-name,
+.statblock.pathfinder-2e-action-layout .trait_01 span.property-name,
+.statblock.pathfinder-2e-action-layout .trait_02 span.property-name,
+.statblock.pathfinder-2e-action-layout .trait_03 span.property-name,
+.statblock.pathfinder-2e-action-layout .trait_04 span.property-name,
+.statblock.pathfinder-2e-action-layout .trait_05 span.property-name,
+.statblock.pathfinder-2e-action-layout .trait_06 span.property-name,
+.statblock.pathfinder-2e-action-layout .trait_07 span.property-name {
+  display: none;
 }
-.statblock.basic-pathfinder-2e-layout
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .image {
-    width: unset;
-    height: unset;
+
+.statblock.pathfinder-2e-hazard-layout .traits {
+  margin: 0 0.25em 0 0;
+  display: inline;
+  font-weight: 900 !important;
+  font-style: normal !important;
 }
-.statblock.basic-pathfinder-2e-layout
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    img {
-    width: unset;
-    height: var(--statblock-property-line-height);
-    border-radius: 0;
-    border: none;
+.statblock.pathfinder-2e-hazard-layout .rare_01 {
+  background-color: var(--statblock-color-common) !important;
+  /* common */
 }
-.statblock.basic-pathfinder-2e-layout ul {
-    display: block;
-    list-style-type: var(--statblock-list-style-type);
-    margin-block-start: var(--statblock-list-margin-block-start);
-    margin-block-end: var(--statblock-list-margin-block-end);
-    margin-inline-start: var(--statblock-list-margin-inline-start);
-    margin-inline-end: var(--statblock-list-margin-inline-end);
-    padding-inline-start: var(--statblock-list-padding-inline-start);
+.statblock.pathfinder-2e-hazard-layout .rare_02 {
+  background-color: var(--statblock-color-uncommon) !important;
+  /* uncommon */
 }
-.statblock.basic-pathfinder-2e-layout .markdown-rendered ul,
-.statblock.basic-pathfinder-2e-layout .markdown-rendered ol {
-    padding-inline-start: var(--statblock-list-indent);
+.statblock.pathfinder-2e-hazard-layout .rare_03 {
+  background-color: var(--statblock-color-rare) !important;
+  /* rare */
 }
-.statblock.basic-pathfinder-2e-layout li {
-    color: var(--statblock-content-font);
-    display: list-item;
-    text-align: var(--statblock-list-text-align);
+.statblock.pathfinder-2e-hazard-layout .rare_04 {
+  background-color: var(--statblock-color-unique) !important;
+  /* unique */
 }
-.statblock.basic-pathfinder-2e-layout .markdown-source-view ol > li,
-.statblock.basic-pathfinder-2e-layout .markdown-source-view ul > li,
-.statblock.basic-pathfinder-2e-layout .markdown-preview-view ol > li,
-.statblock.basic-pathfinder-2e-layout .markdown-preview-view ul > li,
-.statblock.basic-pathfinder-2e-layout .markdown-rendered ul > li,
-.statblock.basic-pathfinder-2e-layout .mod-cm6 .HyperMD-list-line.cm-line {
-    padding-top: var(--statblock-list-padding-top);
-    padding-bottom: var(--statblock-list-padding-bottom);
+.statblock.pathfinder-2e-hazard-layout .alignment {
+  background-color: var(--statblock-color-alignment) !important;
 }
-.statblock.basic-pathfinder-2e-layout ol > li::marker,
-.statblock.basic-pathfinder-2e-layout ul > li::marker,
-.statblock.basic-pathfinder-2e-layout .cm-s-obsidian .cm-formatting-list {
-    color: var(--list-marker-color);
+.statblock.pathfinder-2e-hazard-layout .size {
+  background-color: var(--statblock-color-size) !important;
 }
-.statblock.basic-pathfinder-2e-layout ::marker {
-    unicode-bidi: isolate;
-    font-variant-numeric: tabular-nums;
-    text-transform: none;
-    text-indent: 0;
-    text-align: start;
-    text-align-last: start;
+.statblock.pathfinder-2e-hazard-layout .xp,
+.statblock.pathfinder-2e-hazard-layout .kingdom_xp,
+.statblock.pathfinder-2e-hazard-layout .trait_01,
+.statblock.pathfinder-2e-hazard-layout .trait_02,
+.statblock.pathfinder-2e-hazard-layout .trait_03,
+.statblock.pathfinder-2e-hazard-layout .trait_04,
+.statblock.pathfinder-2e-hazard-layout .trait_05,
+.statblock.pathfinder-2e-hazard-layout .trait_06,
+.statblock.pathfinder-2e-hazard-layout .trait_07 {
+  background-color: var(--statblock-color-trait) !important;
 }
-.statblock.basic-pathfinder-2e-layoutact {
-    --statblock-color-common: rgb(54, 69, 79);
-    --statblock-color-uncommon: rgb(143, 85, 66);
-    --statblock-color-rare: rgb(11, 37, 96);
-    --statblock-color-unique: rgb(77, 27, 106);
-    --statblock-color-alignment: rgb(89, 98, 143);
-    --statblock-color-size: rgb(75, 122, 92);
-    --statblock-color-trait: rgb(86, 12, 6);
-    --statblock-primary-color: rgb(51, 51, 51);
-    --statblock-rule-color: rgb(51, 51, 51);
-    --statblock-background-color: rgb(246, 244, 242);
-    --statblock-background-color-alt: rgb(229, 224, 219);
-    --statblock-bar-color: var(--statblock-rule-color);
-    --statblock-bar-border-size: 1px;
-    --statblock-bar-border-color: var(--statblock-rule-color);
-    --statblock-image-width: 75px;
-    --statblock-image-height: 75px;
-    --statblock-image-border-size: 2px;
-    --statblock-image-border-color: rgb(51, 51, 51);
-    --statblock-border-size: 1px;
-    --statblock-border-color: rgb(51, 51, 51);
-    --statblock-box-shadow-color: rgb(255, 215, 0);
-    --statblock-box-shadow-x-offset: 0;
-    --statblock-box-shadow-y-offset: 0;
-    --statblock-box-shadow-blur: 1.5em;
-    --statblock-font-color: var(--statblock-primary-color);
-    --statblock-font-weight: 400;
-    --statblock-content-font: system-ui, "Pathfinder", -apple-system,
-        BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-        "Open Sans", "Helvetica Neue", sans-serif;
-    --statblock-content-font-size: 13px;
-    --statblock-heading-font: system-ui, "Pathfinder", -apple-system,
-        BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-        "Open Sans", "Helvetica Neue", sans-serif;
-    --statblock-heading-font-color: var(--statblock-font-color);
-    --statblock-heading-font-size: 1.35em;
-    --statblock-heading-font-variant: small-caps;
-    --statblock-heading-font-weight: 700;
-    --statblock-heading-line-height: 1;
-    --statblock-property-line-height: 1.33em;
-    --statblock-property-font-color: var(--statblock-font-color);
-    --statblock-property-name-font-color: var(--statblock-font-color);
-    --statblock-property-name-font-weight: bold;
-    --statblock-section-heading-border-size: 1px;
-    --statblock-section-heading-border-color: transparent;
-    --statblock-section-heading-font-color: var(--statblock-font-color);
-    --statblock-section-heading-font-size: 1.33 empx;
-    --statblock-section-heading-font-variant: small-caps;
-    --statblock-section-heading-font-weight: 400;
-    --statblock-saves-line-height: 1.33em;
-    --statblock-spells-font-style: italic;
-    --statblock-table-header-font-weight: bold;
-    --statblock-other-font: system-ui, "Pathfinder", -apple-system,
-        BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-        "Open Sans", "Helvetica Neue", sans-serif;
-    --statblock-traits-font: system-ui, "Pathfinder", -apple-system,
-        BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-        "Open Sans", "Helvetica Neue", sans-serif;
-    --statblock-text-normal: rgb(--color-base-100);
-    --statblock-text-muted: rgb(--color-base-50);
-    --statblock-text-faint: rgba(--statblock-primary-color, 0.5);
-    --statblock-hyperlink-color: rgb(61, 102, 142);
-    --statblock-hyperlink-text-decoration: rgb(51, 51, 51) underline solid;
-    --statblock-hyperlink-text-shadow: 0.5px 0.5px 0.5px rgba(61, 102, 142);
-    --statblock-italic-font-color: rgb(77, 27, 105);
-    --statblock-h3-variant: small-caps;
-    --statblock-h3-letter-spacing: 1;
-    --statblock-h3-line-height: 1.33em;
-    --statblock-h3-size: 13px;
-    --statblock-h3-color: rgb(51, 51, 51);
-    --statblock-h3-weight: 400;
-    --statblock-h3-font-style: normal;
-    --statblock-h3-font-family: system-ui, "Pathfinder", -apple-system,
-        BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-        "Open Sans", "Helvetica Neue", sans-serif;
-    --statblock-column-width: 400px;
-    --statblock-column2-width: 1000px;
-    --statblock-traits-box-sizing: border-box;
-    --statblock-traits-font-color: rgb(255, 255, 255);
-    --statblock-traits-letter-spacing: 0.01em;
-    --statblock-traits-gap: 2px;
-    --statblock-traits-margins: 0 var(--statblock-traits-gap) 0 0;
-    --statblock-traits-min-width: 4em;
-    --statblock-traits-padding: 0.4em 1.1em 0.2em;
-    --statblock-traits-text-align: center;
-    --statblock-traits-text-transform: uppercase;
-    --statblock-traits-font-size: 12px;
-    --statblock-traits-font-style: normal;
-    --statblock-traits-font-weight: 900;
-    --statblock-list-bullet-border: none;
-    --statblock-list-bullet-radius: 50%;
-    --statblock-list-bullet-size: 0.3em;
-    --statblock-list-bullet-transform: none;
-    --statblock-list-numbered-style: decimal;
-    --statblock-list-indent: 2em;
-    --statblock-list-margin-block-start: 1em;
-    --statblock-list-margin-block-end: 1em;
-    --statblock-list-margin-inline-start: 0px;
-    --statblock-list-margin-inline-end: 0px;
-    --statblock-list-marker-color: blue;
-    --statblock-list-marker-color-collapsed: var(--text-accent);
-    --statblock-list-marker-color-hover: var(--text-muted);
-    --statblock-list-padding-inline-start: 40px;
-    --statblock-list-padding-top: 0;
-    --statblock-list-padding-bottom: 0;
-    --statblock-list-spacing: 0.075em;
-    --statblock-list-style-type: disc;
-    --statblock-list-text-align: -webkit-match-parent;
-    --statblock-upper-level-padding: 2em;
-    --statblock-upper-level-margin: 2em;
+.statblock.pathfinder-2e-hazard-layout .rare_01,
+.statblock.pathfinder-2e-hazard-layout .rare_02,
+.statblock.pathfinder-2e-hazard-layout .rare_03,
+.statblock.pathfinder-2e-hazard-layout .rare_04,
+.statblock.pathfinder-2e-hazard-layout .alignment,
+.statblock.pathfinder-2e-hazard-layout .size,
+.statblock.pathfinder-2e-hazard-layout .xp,
+.statblock.pathfinder-2e-hazard-layout .kingdom_xp,
+.statblock.pathfinder-2e-hazard-layout .trait_01,
+.statblock.pathfinder-2e-hazard-layout .trait_02,
+.statblock.pathfinder-2e-hazard-layout .trait_03,
+.statblock.pathfinder-2e-hazard-layout .trait_04,
+.statblock.pathfinder-2e-hazard-layout .trait_05,
+.statblock.pathfinder-2e-hazard-layout .trait_06,
+.statblock.pathfinder-2e-hazard-layout .trait_07 {
+  color: rgb(255, 255, 255) !important;
+  font-size: 12px;
+  font-style: normal !important;
+  font-weight: 900 !important;
+  letter-spacing: 0.01em;
+  min-width: 4em;
+  margin: 0 var(--statblock-traits-gap) 0 0;
+  padding: 0.4em 1.1em 0.2em;
+  text-align: center;
+  text-transform: uppercase;
 }
-.statblock.basic-pathfinder-2e-layoutact .bar {
-    height: 1px;
-    background: var(--statblock-bar-color);
-    border: var(--statblock-bar-border-size) solid
-        var(--statblock-bar-border-color);
-    z-index: 1;
-    width: fit-content;
+.statblock.pathfinder-2e-hazard-layout .rare_01 span.property-name,
+.statblock.pathfinder-2e-hazard-layout .rare_02 span.property-name,
+.statblock.pathfinder-2e-hazard-layout .rare_03 span.property-name,
+.statblock.pathfinder-2e-hazard-layout .rare_04 span.property-name,
+.statblock.pathfinder-2e-hazard-layout .alignment span.property-name,
+.statblock.pathfinder-2e-hazard-layout .size span.property-name,
+.statblock.pathfinder-2e-hazard-layout .xp span.property-name,
+.statblock.pathfinder-2e-hazard-layout .kingdom_xp span.property-name,
+.statblock.pathfinder-2e-hazard-layout .trait_01 span.property-name,
+.statblock.pathfinder-2e-hazard-layout .trait_02 span.property-name,
+.statblock.pathfinder-2e-hazard-layout .trait_03 span.property-name,
+.statblock.pathfinder-2e-hazard-layout .trait_04 span.property-name,
+.statblock.pathfinder-2e-hazard-layout .trait_05 span.property-name,
+.statblock.pathfinder-2e-hazard-layout .trait_06 span.property-name,
+.statblock.pathfinder-2e-hazard-layout .trait_07 span.property-name {
+  display: none;
 }
-.statblock.basic-pathfinder-2e-layoutact .statblock-content {
-    font-family: var(--statblock-content-font);
-    font-size: var(--statblock-content-font-size);
-    color: var(--statblock-font-color);
-    background-color: var(--statblock-background-color);
-    padding: 0.5em;
-    border: var(--statblock-border-size) var(--statblock-border-color) solid;
-    box-shadow: var(--statblock-box-shadow-x-offset)
-        var(--statblock-box-shadow-y-offset) var(--statblock-box-shadow-blur)
-        var(--statblock-box-shadow-color);
-    margin: 0.5em 2px;
-    display: flex;
-    gap: 1rem;
+
+.statblock.pathfinder-2e-influence-layout .traits {
+  margin: 0 0.25em 0 0;
+  display: inline;
+  font-weight: 900 !important;
+  font-style: normal !important;
 }
-.statblock.basic-pathfinder-2e-layoutact .statblock-content .statblock-detached {
-    position: absolute;
-    top: -9999px;
+.statblock.pathfinder-2e-influence-layout .rare_01 {
+  background-color: var(--statblock-color-common) !important;
+  /* common */
 }
-.statblock.basic-pathfinder-2e-layoutact .statblock-content .statblock-item-container {
-    margin: 0;
-    padding: 0;
+.statblock.pathfinder-2e-influence-layout .rare_02 {
+  background-color: var(--statblock-color-uncommon) !important;
+  /* uncommon */
 }
-.statblock.basic-pathfinder-2e-layoutact .statblock-content .statblock-item-inline {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    align-content: flex-start;
-    align-items: baseline;
-    justify-content: flex-start;
-    margin: 0;
-    padding: 0;
+.statblock.pathfinder-2e-influence-layout .rare_03 {
+  background-color: var(--statblock-color-rare) !important;
+  /* rare */
 }
-.statblock.basic-pathfinder-2e-layoutact .statblock-content > .column {
-    width: var(--statblock-column-width);
+.statblock.pathfinder-2e-influence-layout .rare_04 {
+  background-color: var(--statblock-color-unique) !important;
+  /* unique */
 }
-.statblock.basic-pathfinder-2e-layoutact
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline) {
+.statblock.pathfinder-2e-influence-layout .alignment {
+  background-color: var(--statblock-color-alignment) !important;
 }
-.statblock.basic-pathfinder-2e-layoutact
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline):has(
-        .line,
-        .property
-    ) {
-    margin-block: 0.25rem;
+.statblock.pathfinder-2e-influence-layout .size {
+  background-color: var(--statblock-color-size) !important;
 }
-.statblock.basic-pathfinder-2e-layoutact
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline):has(
-        .line,
-        .property
-    ):last-child {
-    margin-bottom: 0;
+.statblock.pathfinder-2e-influence-layout .xp,
+.statblock.pathfinder-2e-influence-layout .kingdom_xp,
+.statblock.pathfinder-2e-influence-layout .trait_01,
+.statblock.pathfinder-2e-influence-layout .trait_02,
+.statblock.pathfinder-2e-influence-layout .trait_03,
+.statblock.pathfinder-2e-influence-layout .trait_04,
+.statblock.pathfinder-2e-influence-layout .trait_05,
+.statblock.pathfinder-2e-influence-layout .trait_06,
+.statblock.pathfinder-2e-influence-layout .trait_07 {
+  background-color: var(--statblock-color-trait) !important;
 }
-.statblock.basic-pathfinder-2e-layoutact
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline):has(.line.name) {
-    margin: 0;
+.statblock.pathfinder-2e-influence-layout .rare_01,
+.statblock.pathfinder-2e-influence-layout .rare_02,
+.statblock.pathfinder-2e-influence-layout .rare_03,
+.statblock.pathfinder-2e-influence-layout .rare_04,
+.statblock.pathfinder-2e-influence-layout .alignment,
+.statblock.pathfinder-2e-influence-layout .size,
+.statblock.pathfinder-2e-influence-layout .xp,
+.statblock.pathfinder-2e-influence-layout .kingdom_xp,
+.statblock.pathfinder-2e-influence-layout .trait_01,
+.statblock.pathfinder-2e-influence-layout .trait_02,
+.statblock.pathfinder-2e-influence-layout .trait_03,
+.statblock.pathfinder-2e-influence-layout .trait_04,
+.statblock.pathfinder-2e-influence-layout .trait_05,
+.statblock.pathfinder-2e-influence-layout .trait_06,
+.statblock.pathfinder-2e-influence-layout .trait_07 {
+  color: rgb(255, 255, 255) !important;
+  font-size: 12px;
+  font-style: normal !important;
+  font-weight: 900 !important;
+  letter-spacing: 0.01em;
+  min-width: 4em;
+  margin: 0 var(--statblock-traits-gap) 0 0;
+  padding: 0.4em 1.1em 0.2em;
+  text-align: center;
+  text-transform: uppercase;
 }
-.statblock.basic-pathfinder-2e-layoutact
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline)
-    > :is(.property, .line:has(.property-name)) {
-    margin-left: 1em;
+.statblock.pathfinder-2e-influence-layout .rare_01 span.property-name,
+.statblock.pathfinder-2e-influence-layout .rare_02 span.property-name,
+.statblock.pathfinder-2e-influence-layout .rare_03 span.property-name,
+.statblock.pathfinder-2e-influence-layout .rare_04 span.property-name,
+.statblock.pathfinder-2e-influence-layout .alignment span.property-name,
+.statblock.pathfinder-2e-influence-layout .size span.property-name,
+.statblock.pathfinder-2e-influence-layout .xp span.property-name,
+.statblock.pathfinder-2e-influence-layout .kingdom_xp span.property-name,
+.statblock.pathfinder-2e-influence-layout .trait_01 span.property-name,
+.statblock.pathfinder-2e-influence-layout .trait_02 span.property-name,
+.statblock.pathfinder-2e-influence-layout .trait_03 span.property-name,
+.statblock.pathfinder-2e-influence-layout .trait_04 span.property-name,
+.statblock.pathfinder-2e-influence-layout .trait_05 span.property-name,
+.statblock.pathfinder-2e-influence-layout .trait_06 span.property-name,
+.statblock.pathfinder-2e-influence-layout .trait_07 span.property-name {
+  display: none;
 }
-.statblock.basic-pathfinder-2e-layoutact
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline)
-    > :is(.property, .line)
-    .property-name {
-    margin-left: -1em;
+
+.statblock.pathfinder-2e-misc-layout .traits {
+  margin: 0 0.25em 0 0;
+  display: inline;
+  font-weight: 900 !important;
+  font-style: normal !important;
 }
-.statblock.basic-pathfinder-2e-layoutact
-    .statblock-content
-    > .column
-    > .statblock-item-container:has(.tapered-rule) {
-    margin-block: 0.25rem;
+.statblock.pathfinder-2e-misc-layout .rare_01 {
+  background-color: var(--statblock-color-common) !important;
+  /* common */
 }
-.statblock.basic-pathfinder-2e-layoutact
-    .statblock-content
-    > .column
-    > .statblock-item-inline:has(.name)
-    + .statblock-item-container:has(.tapered-rule) {
-    margin-top: 0;
+.statblock.pathfinder-2e-misc-layout .rare_02 {
+  background-color: var(--statblock-color-uncommon) !important;
+  /* uncommon */
 }
-.statblock.basic-pathfinder-2e-layoutact
-    .statblock-content
-    > .column
-    > .statblock-item-inline:has(
-        .rare_01,
-        .rare_02,
-        .rare_03,
-        .rare_04,
-        .alignment,
-        .size,
-        .xp,
-        .kingdom_xp,
-        .trait_01,
-        .trait_02,
-        .trait_03,
-        .trait_04,
-        .trait_05,
-        .trait_06,
-        .trait_07
-    ) {
-    row-gap: var(--statblock-traits-gap);
-    margin-bottom: 0.5em;
+.statblock.pathfinder-2e-misc-layout .rare_03 {
+  background-color: var(--statblock-color-rare) !important;
+  /* rare */
 }
+.statblock.pathfinder-2e-misc-layout .rare_04 {
+  background-color: var(--statblock-color-unique) !important;
+  /* unique */
+}
+.statblock.pathfinder-2e-misc-layout .alignment {
+  background-color: var(--statblock-color-alignment) !important;
+}
+.statblock.pathfinder-2e-misc-layout .size {
+  background-color: var(--statblock-color-size) !important;
+}
+.statblock.pathfinder-2e-misc-layout .xp,
+.statblock.pathfinder-2e-misc-layout .kingdom_xp,
+.statblock.pathfinder-2e-misc-layout .trait_01,
+.statblock.pathfinder-2e-misc-layout .trait_02,
+.statblock.pathfinder-2e-misc-layout .trait_03,
+.statblock.pathfinder-2e-misc-layout .trait_04,
+.statblock.pathfinder-2e-misc-layout .trait_05,
+.statblock.pathfinder-2e-misc-layout .trait_06,
+.statblock.pathfinder-2e-misc-layout .trait_07 {
+  background-color: var(--statblock-color-trait) !important;
+}
+.statblock.pathfinder-2e-misc-layout .rare_01,
+.statblock.pathfinder-2e-misc-layout .rare_02,
+.statblock.pathfinder-2e-misc-layout .rare_03,
+.statblock.pathfinder-2e-misc-layout .rare_04,
+.statblock.pathfinder-2e-misc-layout .alignment,
+.statblock.pathfinder-2e-misc-layout .size,
+.statblock.pathfinder-2e-misc-layout .xp,
+.statblock.pathfinder-2e-misc-layout .kingdom_xp,
+.statblock.pathfinder-2e-misc-layout .trait_01,
+.statblock.pathfinder-2e-misc-layout .trait_02,
+.statblock.pathfinder-2e-misc-layout .trait_03,
+.statblock.pathfinder-2e-misc-layout .trait_04,
+.statblock.pathfinder-2e-misc-layout .trait_05,
+.statblock.pathfinder-2e-misc-layout .trait_06,
+.statblock.pathfinder-2e-misc-layout .trait_07 {
+  color: rgb(255, 255, 255) !important;
+  font-size: 12px;
+  font-style: normal !important;
+  font-weight: 900 !important;
+  letter-spacing: 0.01em;
+  min-width: 4em;
+  margin: 0 var(--statblock-traits-gap) 0 0;
+  padding: 0.4em 1.1em 0.2em;
+  text-align: center;
+  text-transform: uppercase;
+}
+.statblock.pathfinder-2e-misc-layout .rare_01 span.property-name,
+.statblock.pathfinder-2e-misc-layout .rare_02 span.property-name,
+.statblock.pathfinder-2e-misc-layout .rare_03 span.property-name,
+.statblock.pathfinder-2e-misc-layout .rare_04 span.property-name,
+.statblock.pathfinder-2e-misc-layout .alignment span.property-name,
+.statblock.pathfinder-2e-misc-layout .size span.property-name,
+.statblock.pathfinder-2e-misc-layout .xp span.property-name,
+.statblock.pathfinder-2e-misc-layout .kingdom_xp span.property-name,
+.statblock.pathfinder-2e-misc-layout .trait_01 span.property-name,
+.statblock.pathfinder-2e-misc-layout .trait_02 span.property-name,
+.statblock.pathfinder-2e-misc-layout .trait_03 span.property-name,
+.statblock.pathfinder-2e-misc-layout .trait_04 span.property-name,
+.statblock.pathfinder-2e-misc-layout .trait_05 span.property-name,
+.statblock.pathfinder-2e-misc-layout .trait_06 span.property-name,
+.statblock.pathfinder-2e-misc-layout .trait_07 span.property-name {
+  display: none;
+}
+
+.statblock.pathfinder-2e-quest-layout .traits {
+  margin: 0 0.25em 0 0;
+  display: inline;
+  font-weight: 900 !important;
+  font-style: normal !important;
+}
+.statblock.pathfinder-2e-quest-layout .rare_01 {
+  background-color: var(--statblock-color-common) !important;
+  /* common */
+}
+.statblock.pathfinder-2e-quest-layout .rare_02 {
+  background-color: var(--statblock-color-uncommon) !important;
+  /* uncommon */
+}
+.statblock.pathfinder-2e-quest-layout .rare_03 {
+  background-color: var(--statblock-color-rare) !important;
+  /* rare */
+}
+.statblock.pathfinder-2e-quest-layout .rare_04 {
+  background-color: var(--statblock-color-unique) !important;
+  /* unique */
+}
+.statblock.pathfinder-2e-quest-layout .alignment {
+  background-color: var(--statblock-color-alignment) !important;
+}
+.statblock.pathfinder-2e-quest-layout .size {
+  background-color: var(--statblock-color-size) !important;
+}
+.statblock.pathfinder-2e-quest-layout .xp,
+.statblock.pathfinder-2e-quest-layout .kingdom_xp,
+.statblock.pathfinder-2e-quest-layout .trait_01,
+.statblock.pathfinder-2e-quest-layout .trait_02,
+.statblock.pathfinder-2e-quest-layout .trait_03,
+.statblock.pathfinder-2e-quest-layout .trait_04,
+.statblock.pathfinder-2e-quest-layout .trait_05,
+.statblock.pathfinder-2e-quest-layout .trait_06,
+.statblock.pathfinder-2e-quest-layout .trait_07 {
+  background-color: var(--statblock-color-trait) !important;
+}
+.statblock.pathfinder-2e-quest-layout .rare_01,
+.statblock.pathfinder-2e-quest-layout .rare_02,
+.statblock.pathfinder-2e-quest-layout .rare_03,
+.statblock.pathfinder-2e-quest-layout .rare_04,
+.statblock.pathfinder-2e-quest-layout .alignment,
+.statblock.pathfinder-2e-quest-layout .size,
+.statblock.pathfinder-2e-quest-layout .xp,
+.statblock.pathfinder-2e-quest-layout .kingdom_xp,
+.statblock.pathfinder-2e-quest-layout .trait_01,
+.statblock.pathfinder-2e-quest-layout .trait_02,
+.statblock.pathfinder-2e-quest-layout .trait_03,
+.statblock.pathfinder-2e-quest-layout .trait_04,
+.statblock.pathfinder-2e-quest-layout .trait_05,
+.statblock.pathfinder-2e-quest-layout .trait_06,
+.statblock.pathfinder-2e-quest-layout .trait_07 {
+  color: rgb(255, 255, 255) !important;
+  font-size: 12px;
+  font-style: normal !important;
+  font-weight: 900 !important;
+  letter-spacing: 0.01em;
+  min-width: 4em;
+  margin: 0 var(--statblock-traits-gap) 0 0;
+  padding: 0.4em 1.1em 0.2em;
+  text-align: center;
+  text-transform: uppercase;
+}
+.statblock.pathfinder-2e-quest-layout .rare_01 span.property-name,
+.statblock.pathfinder-2e-quest-layout .rare_02 span.property-name,
+.statblock.pathfinder-2e-quest-layout .rare_03 span.property-name,
+.statblock.pathfinder-2e-quest-layout .rare_04 span.property-name,
+.statblock.pathfinder-2e-quest-layout .alignment span.property-name,
+.statblock.pathfinder-2e-quest-layout .size span.property-name,
+.statblock.pathfinder-2e-quest-layout .xp span.property-name,
+.statblock.pathfinder-2e-quest-layout .kingdom_xp span.property-name,
+.statblock.pathfinder-2e-quest-layout .trait_01 span.property-name,
+.statblock.pathfinder-2e-quest-layout .trait_02 span.property-name,
+.statblock.pathfinder-2e-quest-layout .trait_03 span.property-name,
+.statblock.pathfinder-2e-quest-layout .trait_04 span.property-name,
+.statblock.pathfinder-2e-quest-layout .trait_05 span.property-name,
+.statblock.pathfinder-2e-quest-layout .trait_06 span.property-name,
+.statblock.pathfinder-2e-quest-layout .trait_07 span.property-name {
+  display: none;
+}
+
+.statblock.pathfinder-2e-settlement-layout .traits {
+  margin: 0 0.25em 0 0;
+  display: inline;
+  font-weight: 900 !important;
+  font-style: normal !important;
+}
+.statblock.pathfinder-2e-settlement-layout .rare_01 {
+  background-color: var(--statblock-color-common) !important;
+  /* common */
+}
+.statblock.pathfinder-2e-settlement-layout .rare_02 {
+  background-color: var(--statblock-color-uncommon) !important;
+  /* uncommon */
+}
+.statblock.pathfinder-2e-settlement-layout .rare_03 {
+  background-color: var(--statblock-color-rare) !important;
+  /* rare */
+}
+.statblock.pathfinder-2e-settlement-layout .rare_04 {
+  background-color: var(--statblock-color-unique) !important;
+  /* unique */
+}
+.statblock.pathfinder-2e-settlement-layout .alignment {
+  background-color: var(--statblock-color-alignment) !important;
+}
+.statblock.pathfinder-2e-settlement-layout .size {
+  background-color: var(--statblock-color-size) !important;
+}
+.statblock.pathfinder-2e-settlement-layout .xp,
+.statblock.pathfinder-2e-settlement-layout .kingdom_xp,
+.statblock.pathfinder-2e-settlement-layout .trait_01,
+.statblock.pathfinder-2e-settlement-layout .trait_02,
+.statblock.pathfinder-2e-settlement-layout .trait_03,
+.statblock.pathfinder-2e-settlement-layout .trait_04,
+.statblock.pathfinder-2e-settlement-layout .trait_05,
+.statblock.pathfinder-2e-settlement-layout .trait_06,
+.statblock.pathfinder-2e-settlement-layout .trait_07 {
+  background-color: var(--statblock-color-trait) !important;
+}
+.statblock.pathfinder-2e-settlement-layout .rare_01,
+.statblock.pathfinder-2e-settlement-layout .rare_02,
+.statblock.pathfinder-2e-settlement-layout .rare_03,
+.statblock.pathfinder-2e-settlement-layout .rare_04,
+.statblock.pathfinder-2e-settlement-layout .alignment,
+.statblock.pathfinder-2e-settlement-layout .size,
+.statblock.pathfinder-2e-settlement-layout .xp,
+.statblock.pathfinder-2e-settlement-layout .kingdom_xp,
+.statblock.pathfinder-2e-settlement-layout .trait_01,
+.statblock.pathfinder-2e-settlement-layout .trait_02,
+.statblock.pathfinder-2e-settlement-layout .trait_03,
+.statblock.pathfinder-2e-settlement-layout .trait_04,
+.statblock.pathfinder-2e-settlement-layout .trait_05,
+.statblock.pathfinder-2e-settlement-layout .trait_06,
+.statblock.pathfinder-2e-settlement-layout .trait_07 {
+  color: rgb(255, 255, 255) !important;
+  font-size: 12px;
+  font-style: normal !important;
+  font-weight: 900 !important;
+  letter-spacing: 0.01em;
+  min-width: 4em;
+  margin: 0 var(--statblock-traits-gap) 0 0;
+  padding: 0.4em 1.1em 0.2em;
+  text-align: center;
+  text-transform: uppercase;
+}
+.statblock.pathfinder-2e-settlement-layout .rare_01 span.property-name,
+.statblock.pathfinder-2e-settlement-layout .rare_02 span.property-name,
+.statblock.pathfinder-2e-settlement-layout .rare_03 span.property-name,
+.statblock.pathfinder-2e-settlement-layout .rare_04 span.property-name,
+.statblock.pathfinder-2e-settlement-layout .alignment span.property-name,
+.statblock.pathfinder-2e-settlement-layout .size span.property-name,
+.statblock.pathfinder-2e-settlement-layout .xp span.property-name,
+.statblock.pathfinder-2e-settlement-layout .kingdom_xp span.property-name,
+.statblock.pathfinder-2e-settlement-layout .trait_01 span.property-name,
+.statblock.pathfinder-2e-settlement-layout .trait_02 span.property-name,
+.statblock.pathfinder-2e-settlement-layout .trait_03 span.property-name,
+.statblock.pathfinder-2e-settlement-layout .trait_04 span.property-name,
+.statblock.pathfinder-2e-settlement-layout .trait_05 span.property-name,
+.statblock.pathfinder-2e-settlement-layout .trait_06 span.property-name,
+.statblock.pathfinder-2e-settlement-layout .trait_07 span.property-name {
+  display: none;
+}
+
+.statblock.basic-pathfinder-2e-layout .dice-roller-result {
+  font-weight: var(--statblock-font-weight);
+}
+.statblock.basic-pathfinder-2e-layout .roller-result {
+  font-weight: var(--statblock-font-weight);
+}
+
+.statblock.pathfinder-2e-action-layout .dice-roller-result {
+  font-weight: var(--statblock-font-weight);
+}
+.statblock.pathfinder-2e-action-layout .roller-result {
+  font-weight: var(--statblock-font-weight);
+}
+
+.statblock.pathfinder-2e-hazard-layout .dice-roller-result {
+  font-weight: var(--statblock-font-weight);
+}
+.statblock.pathfinder-2e-hazard-layout .roller-result {
+  font-weight: var(--statblock-font-weight);
+}
+
+.statblock.pathfinder-2e-influence-layout .dice-roller-result {
+  font-weight: var(--statblock-font-weight);
+}
+.statblock.pathfinder-2e-influence-layout .roller-result {
+  font-weight: var(--statblock-font-weight);
+}
+
+.statblock.pathfinder-2e-misc-layout .dice-roller-result {
+  font-weight: var(--statblock-font-weight);
+}
+.statblock.pathfinder-2e-misc-layout .roller-result {
+  font-weight: var(--statblock-font-weight);
+}
+
+.statblock.pathfinder-2e-quest-layout .dice-roller-result {
+  font-weight: var(--statblock-font-weight);
+}
+.statblock.pathfinder-2e-quest-layout .roller-result {
+  font-weight: var(--statblock-font-weight);
+}
+
+.statblock.pathfinder-2e-settlement-layout .dice-roller-result {
+  font-weight: var(--statblock-font-weight);
+}
+.statblock.pathfinder-2e-settlement-layout .roller-result {
+  font-weight: var(--statblock-font-weight);
+}
+
 @media screen and (max-width: 400px) {
-    .statblock.basic-pathfinder-2e-layoutact .statblock-content > :global(.column) {
-        width: 75vw;
-    }
-}
-.statblock.basic-pathfinder-2e-layoutact .dice-roller-result {
-    font-weight: var(--statblock-font-weight);
-}
-.statblock.basic-pathfinder-2e-layoutact .roller-result {
-    font-weight: var(--statblock-font-weight);
-}
-.statblock.basic-pathfinder-2e-layoutact .image {
-    width: var(--statblock-image-width);
-    height: var(--statblock-image-height);
-}
-.statblock.basic-pathfinder-2e-layoutact .image.pointer {
-    cursor: pointer;
-}
-.statblock.basic-pathfinder-2e-layoutact .image img {
-    object-fit: cover;
-    width: 100%;
-    height: 100%;
-    border-radius: 100%;
-    border: var(--statblock-image-border-size) solid
-        var(--statblock-image-border-color);
-    object-position: center;
-}
-.statblock.basic-pathfinder-2e-layoutact .line {
-    line-height: var(--statblock-property-line-height);
-    display: block;
-    color: var(--statblock-property-line-font-color);
-}
-.statblock.basic-pathfinder-2e-layoutact .statblock-rendered-text-content {
-    color: var(--statblock-property-name-font-color);
-    font-weight: var(--statblock-property-name-font-weight);
-}
-.statblock.basic-pathfinder-2e-layoutact .statblock-markdown,
-.statblock.basic-pathfinder-2e-layoutact .property {
-    line-height: var(--statblock-property-line-height);
-}
-.statblock.basic-pathfinder-2e-layoutact div.tapered-rule {
-    width: auto;
-    margin: 0;
-    height: 1px;
-    background: var(--statblock-bar-color);
-    clip-path: unset !important;
-    -webkit-clip-path: unset;
-}
-.statblock.basic-pathfinder-2e-layoutact .flex-container {
-    align-items: center;
-    display: flex;
-    justify-content: space-between;
-}
-.statblock.basic-pathfinder-2e-layoutact .heading {
-    align-items: center;
-    color: var(--statblock-heading-font-color);
-    display: flex;
-    font-family: var(--statblock-heading-font);
-    font-variant: var(--statblock-heading-font-variant);
-    font-weight: var(--statblock-heading-font-weight);
-    justify-content: space-between;
-    line-height: var(--statblock-heading-line-height);
-    letter-spacing: 1px;
-    margin: 0;
-}
-.statblock.basic-pathfinder-2e-layoutact h1.section-header {
-    border: none;
-    color: var(--statblock-section-heading-font-color);
-    font-size: var(--statblock-section-heading-font-size);
-    font-variant: var(--statblock-section-heading-font-variant);
-    font-weight: var(--statblock-section-heading-font-weight);
-    letter-spacing: 1px;
-    margin: 0;
-    margin-bottom: 0.3em;
-    break-inside: avoid-column;
-    break-after: avoid-column;
-}
-.statblock.basic-pathfinder-2e-layoutact h2.section-header {
-    border: none;
-    color: var(--statblock-section-heading-font-color);
-    font-size: var(--statblock-section-heading-font-size);
-    font-variant: var(--statblock-section-heading-font-variant);
-    font-weight: var(--statblock-section-heading-font-weight);
-    letter-spacing: 1px;
-    margin: 0;
-    margin-bottom: 0.3em;
-    break-inside: avoid-column;
-    break-after: avoid-column;
-}
-.statblock.basic-pathfinder-2e-layoutact h3.section-header {
-    border: none;
-    color: var(--statblock-section-heading-font-color);
-    font-size: var(--statblock-section-heading-font-size);
-    font-variant: var(--statblock-section-heading-font-variant);
-    font-weight: var(--statblock-section-heading-font-weight);
-    letter-spacing: 1px;
-    margin: 0;
-    margin-bottom: 0;
-    break-inside: avoid-column;
-    break-after: avoid-column;
-    display: none;
-}
-.statblock.basic-pathfinder-2e-layoutact .spell-line .spells {
-    font-style: var(--statblock-spells-font-style);
-}
-.statblock.basic-pathfinder-2e-layoutact .statblock-table-header {
-    font-weight: var(--statblock-table-header-font-weight);
-}
-.statblock.basic-pathfinder-2e-layoutact .table {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: center;
-    flex-wrap: wrap;
-}
-.statblock.basic-pathfinder-2e-layoutact .table-item {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    flex-flow: column nowrap;
-}
-.statblock.basic-pathfinder-2e-layoutact .traits {
-    margin: 0 0.25em 0 0;
-    display: inline;
-    font-weight: var(--statblock-traits-font-weight) !important;
-    font-style: var(--statblock-traits-font-style) !important;
-}
-.statblock.basic-pathfinder-2e-layoutact .rare_01 {
-    background-color: var(--statblock-color-common) !important;
-}
-.statblock.basic-pathfinder-2e-layoutact .rare_02 {
-    background-color: var(--statblock-color-uncommon) !important;
-}
-.statblock.basic-pathfinder-2e-layoutact .rare_03 {
-    background-color: var(--statblock-color-rare) !important;
-}
-.statblock.basic-pathfinder-2e-layoutact .rare_04 {
-    background-color: var(--statblock-color-unique) !important;
-}
-.statblock.basic-pathfinder-2e-layoutact .alignment {
-    background-color: var(--statblock-color-alignment) !important;
-}
-.statblock.basic-pathfinder-2e-layoutact .size {
-    background-color: var(--statblock-color-size) !important;
-}
-.statblock.basic-pathfinder-2e-layoutact .xp,
-.statblock.basic-pathfinder-2e-layoutact .kingdom_xp,
-.statblock.basic-pathfinder-2e-layoutact .trait_01,
-.statblock.basic-pathfinder-2e-layoutact .trait_02,
-.statblock.basic-pathfinder-2e-layoutact .trait_03,
-.statblock.basic-pathfinder-2e-layoutact .trait_04,
-.statblock.basic-pathfinder-2e-layoutact .trait_05,
-.statblock.basic-pathfinder-2e-layoutact .trait_06,
-.statblock.basic-pathfinder-2e-layoutact .trait_07 {
-    background-color: var(--statblock-color-trait) !important;
-}
-.statblock.basic-pathfinder-2e-layoutact .rare_01,
-.statblock.basic-pathfinder-2e-layoutact .rare_02,
-.statblock.basic-pathfinder-2e-layoutact .rare_03,
-.statblock.basic-pathfinder-2e-layoutact .rare_04,
-.statblock.basic-pathfinder-2e-layoutact .alignment,
-.statblock.basic-pathfinder-2e-layoutact .size,
-.statblock.basic-pathfinder-2e-layoutact .xp,
-.statblock.basic-pathfinder-2e-layoutact .kingdom_xp,
-.statblock.basic-pathfinder-2e-layoutact .trait_01,
-.statblock.basic-pathfinder-2e-layoutact .trait_02,
-.statblock.basic-pathfinder-2e-layoutact .trait_03,
-.statblock.basic-pathfinder-2e-layoutact .trait_04,
-.statblock.basic-pathfinder-2e-layoutact .trait_05,
-.statblock.basic-pathfinder-2e-layoutact .trait_06,
-.statblock.basic-pathfinder-2e-layoutact .trait_07 {
-    color: var(--statblock-traits-font-color) !important;
-    font-size: var(--statblock-traits-font-size);
-    font-style: var(--statblock-traits-font-style) !important;
-    font-weight: var(--statblock-traits-font-weight) !important;
-    letter-spacing: var(--statblock-traits-letter-spacing);
-    min-width: var(--statblock-traits-min-width);
-    margin: var(--statblock-traits-margins);
-    padding: var(--statblock-traits-padding);
-    text-align: var(--statblock-traits-text-align);
-    text-transform: var(--statblock-traits-text-transform);
-}
-.statblock.basic-pathfinder-2e-layoutact .rare_01 span.property-name,
-.statblock.basic-pathfinder-2e-layoutact .rare_02 span.property-name,
-.statblock.basic-pathfinder-2e-layoutact .rare_03 span.property-name,
-.statblock.basic-pathfinder-2e-layoutact .rare_04 span.property-name,
-.statblock.basic-pathfinder-2e-layoutact .alignment span.property-name,
-.statblock.basic-pathfinder-2e-layoutact .size span.property-name,
-.statblock.basic-pathfinder-2e-layoutact .xp span.property-name,
-.statblock.basic-pathfinder-2e-layoutact .kingdom_xp span.property-name,
-.statblock.basic-pathfinder-2e-layoutact .trait_01 span.property-name,
-.statblock.basic-pathfinder-2e-layoutact .trait_02 span.property-name,
-.statblock.basic-pathfinder-2e-layoutact .trait_03 span.property-name,
-.statblock.basic-pathfinder-2e-layoutact .trait_04 span.property-name,
-.statblock.basic-pathfinder-2e-layoutact .trait_05 span.property-name,
-.statblock.basic-pathfinder-2e-layoutact .trait_06 span.property-name,
-.statblock.basic-pathfinder-2e-layoutact .trait_07 span.property-name {
-    display: none;
-}
-.statblock.basic-pathfinder-2e-layoutact h3,
-.statblock.basic-pathfinder-2e-layoutact .markdown-rendered h3,
-.statblock.basic-pathfinder-2e-layoutact .HyperMD-header-3,
-.statblock.basic-pathfinder-2e-layoutact .inline-title[data-level="3"],
-.statblock.basic-pathfinder-2e-layoutact .HyperMD-list-line .cm-header-3 {
-    font-variant: var(--statblock-h3-variant);
-    letter-spacing: var(--statblock-h3-letter-spacing);
-    line-height: var(--statblock-h3-line-height);
-    font-size: var(--statblock-h3-size);
-    color: var(--statblock-h3-color);
-}
-.statblock.basic-pathfinder-2e-layoutact a,
-.statblock.basic-pathfinder-2e-layoutact a:-webkit-any-link,
-.statblock.basic-pathfinder-2e-layoutact a.internal-link {
-    color: var(--statblock-hyperlink-color);
-    font-weight: bolder;
-    text-decoration: var(--statblock-hyperlink-text-decoration);
-}
-.statblock.basic-pathfinder-2e-layoutact b,
-.statblock.basic-pathfinder-2e-layoutact strong,
-.statblock.basic-pathfinder-2e-layoutact .cm-strong {
-    font-weight: var(--statblock-property-name-font-weight);
-    color: var(--statblock-property-name-font-color);
-}
-.statblock.basic-pathfinder-2e-layoutact i,
-.statblock.basic-pathfinder-2e-layoutact em,
-.statblock.basic-pathfinder-2e-layoutact .cm-em {
-    font-style: italic;
-    color: var(--statblock-italic-font-color);
-    font-weight: 500;
-}
-.statblock.basic-pathfinder-2e-layoutact
-    .statblock-item-inline:has(.statblock-inline-item .name) {
-    display: flex;
-    flex-direction: row;
-    margin-inline: 0.25em;
-    gap: 0.25em;
-}
-.statblock.basic-pathfinder-2e-layoutact
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item {
-}
-.statblock.basic-pathfinder-2e-layoutact
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item:has(.name) {
-    flex: 1;
-}
-.statblock.basic-pathfinder-2e-layoutact
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .name,
-.statblock.basic-pathfinder-2e-layoutact
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .level {
-}
-.statblock.basic-pathfinder-2e-layoutact
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .name
-    p,
-.statblock.basic-pathfinder-2e-layoutact
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .level
-    p {
-    align-self: flex-start;
-    font-size: 1.2em;
-    font-weight: 900;
-    text-transform: uppercase;
-}
-.statblock.basic-pathfinder-2e-layoutact
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .name
-    span.property-name,
-.statblock.basic-pathfinder-2e-layoutact
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .level
-    span.property-name {
-    display: none;
-}
-.statblock.basic-pathfinder-2e-layoutact
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .image {
-    width: unset;
-    height: unset;
-}
-.statblock.basic-pathfinder-2e-layoutact
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    img {
-    width: unset;
-    height: var(--statblock-property-line-height);
-    border-radius: 0;
-    border: none;
-}
-.statblock.basic-pathfinder-2e-layoutact ul {
-    display: block;
-    list-style-type: var(--statblock-list-style-type);
-    margin-block-start: var(--statblock-list-margin-block-start);
-    margin-block-end: var(--statblock-list-margin-block-end);
-    margin-inline-start: var(--statblock-list-margin-inline-start);
-    margin-inline-end: var(--statblock-list-margin-inline-end);
-    padding-inline-start: var(--statblock-list-padding-inline-start);
-}
-.statblock.basic-pathfinder-2e-layoutact .markdown-rendered ul,
-.statblock.basic-pathfinder-2e-layoutact .markdown-rendered ol {
-    padding-inline-start: var(--statblock-list-indent);
-}
-.statblock.basic-pathfinder-2e-layoutact li {
-    color: var(--statblock-content-font);
-    display: list-item;
-    text-align: var(--statblock-list-text-align);
-}
-.statblock.basic-pathfinder-2e-layoutact .markdown-source-view ol > li,
-.statblock.basic-pathfinder-2e-layoutact .markdown-source-view ul > li,
-.statblock.basic-pathfinder-2e-layoutact .markdown-preview-view ol > li,
-.statblock.basic-pathfinder-2e-layoutact .markdown-preview-view ul > li,
-.statblock.basic-pathfinder-2e-layoutact .markdown-rendered ul > li,
-.statblock.basic-pathfinder-2e-layoutact .mod-cm6 .HyperMD-list-line.cm-line {
-    padding-top: var(--statblock-list-padding-top);
-    padding-bottom: var(--statblock-list-padding-bottom);
-}
-.statblock.basic-pathfinder-2e-layoutact ol > li::marker,
-.statblock.basic-pathfinder-2e-layoutact ul > li::marker,
-.statblock.basic-pathfinder-2e-layoutact .cm-s-obsidian .cm-formatting-list {
-    color: var(--list-marker-color);
-}
-.statblock.basic-pathfinder-2e-layoutact ::marker {
-    unicode-bidi: isolate;
-    font-variant-numeric: tabular-nums;
-    text-transform: none;
-    text-indent: 0;
-    text-align: start;
-    text-align-last: start;
-}
-.statblock.basic-pathfinder-2e-layouthaz {
-    --statblock-color-common: rgb(54, 69, 79);
-    --statblock-color-uncommon: rgb(143, 85, 66);
-    --statblock-color-rare: rgb(11, 37, 96);
-    --statblock-color-unique: rgb(77, 27, 106);
-    --statblock-color-alignment: rgb(89, 98, 143);
-    --statblock-color-size: rgb(75, 122, 92);
-    --statblock-color-trait: rgb(86, 12, 6);
-    --statblock-primary-color: rgb(51, 51, 51);
-    --statblock-rule-color: rgb(51, 51, 51);
-    --statblock-background-color: rgb(246, 244, 242);
-    --statblock-background-color-alt: rgb(229, 224, 219);
-    --statblock-bar-color: var(--statblock-rule-color);
-    --statblock-bar-border-size: 1px;
-    --statblock-bar-border-color: var(--statblock-rule-color);
-    --statblock-image-width: 75px;
-    --statblock-image-height: 75px;
-    --statblock-image-border-size: 2px;
-    --statblock-image-border-color: rgb(51, 51, 51);
-    --statblock-border-size: 1px;
-    --statblock-border-color: rgb(51, 51, 51);
-    --statblock-box-shadow-color: rgb(255, 215, 0);
-    --statblock-box-shadow-x-offset: 0;
-    --statblock-box-shadow-y-offset: 0;
-    --statblock-box-shadow-blur: 1.5em;
-    --statblock-font-color: var(--statblock-primary-color);
-    --statblock-font-weight: 400;
-    --statblock-content-font: system-ui, "Pathfinder", -apple-system,
-        BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-        "Open Sans", "Helvetica Neue", sans-serif;
-    --statblock-content-font-size: 13px;
-    --statblock-heading-font: system-ui, "Pathfinder", -apple-system,
-        BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-        "Open Sans", "Helvetica Neue", sans-serif;
-    --statblock-heading-font-color: var(--statblock-font-color);
-    --statblock-heading-font-size: 1.35em;
-    --statblock-heading-font-variant: small-caps;
-    --statblock-heading-font-weight: 700;
-    --statblock-heading-line-height: 1;
-    --statblock-property-line-height: 1.33em;
-    --statblock-property-font-color: var(--statblock-font-color);
-    --statblock-property-name-font-color: var(--statblock-font-color);
-    --statblock-property-name-font-weight: bold;
-    --statblock-section-heading-border-size: 1px;
-    --statblock-section-heading-border-color: transparent;
-    --statblock-section-heading-font-color: var(--statblock-font-color);
-    --statblock-section-heading-font-size: 1.33 empx;
-    --statblock-section-heading-font-variant: small-caps;
-    --statblock-section-heading-font-weight: 400;
-    --statblock-saves-line-height: 1.33em;
-    --statblock-spells-font-style: italic;
-    --statblock-table-header-font-weight: bold;
-    --statblock-other-font: system-ui, "Pathfinder", -apple-system,
-        BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-        "Open Sans", "Helvetica Neue", sans-serif;
-    --statblock-traits-font: system-ui, "Pathfinder", -apple-system,
-        BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-        "Open Sans", "Helvetica Neue", sans-serif;
-    --statblock-text-normal: rgb(--color-base-100);
-    --statblock-text-muted: rgb(--color-base-50);
-    --statblock-text-faint: rgba(--statblock-primary-color, 0.5);
-    --statblock-hyperlink-color: rgb(61, 102, 142);
-    --statblock-hyperlink-text-decoration: rgb(51, 51, 51) underline solid;
-    --statblock-hyperlink-text-shadow: 0.5px 0.5px 0.5px rgba(61, 102, 142);
-    --statblock-italic-font-color: rgb(77, 27, 105);
-    --statblock-h3-variant: small-caps;
-    --statblock-h3-letter-spacing: 1;
-    --statblock-h3-line-height: 1.33em;
-    --statblock-h3-size: 13px;
-    --statblock-h3-color: rgb(51, 51, 51);
-    --statblock-h3-weight: 400;
-    --statblock-h3-font-style: normal;
-    --statblock-h3-font-family: system-ui, "Pathfinder", -apple-system,
-        BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-        "Open Sans", "Helvetica Neue", sans-serif;
-    --statblock-column-width: 400px;
-    --statblock-column2-width: 1000px;
-    --statblock-traits-box-sizing: border-box;
-    --statblock-traits-font-color: rgb(255, 255, 255);
-    --statblock-traits-letter-spacing: 0.01em;
-    --statblock-traits-gap: 2px;
-    --statblock-traits-margins: 0 var(--statblock-traits-gap) 0 0;
-    --statblock-traits-min-width: 4em;
-    --statblock-traits-padding: 0.4em 1.1em 0.2em;
-    --statblock-traits-text-align: center;
-    --statblock-traits-text-transform: uppercase;
-    --statblock-traits-font-size: 12px;
-    --statblock-traits-font-style: normal;
-    --statblock-traits-font-weight: 900;
-    --statblock-list-bullet-border: none;
-    --statblock-list-bullet-radius: 50%;
-    --statblock-list-bullet-size: 0.3em;
-    --statblock-list-bullet-transform: none;
-    --statblock-list-numbered-style: decimal;
-    --statblock-list-indent: 2em;
-    --statblock-list-margin-block-start: 1em;
-    --statblock-list-margin-block-end: 1em;
-    --statblock-list-margin-inline-start: 0px;
-    --statblock-list-margin-inline-end: 0px;
-    --statblock-list-marker-color: blue;
-    --statblock-list-marker-color-collapsed: var(--text-accent);
-    --statblock-list-marker-color-hover: var(--text-muted);
-    --statblock-list-padding-inline-start: 40px;
-    --statblock-list-padding-top: 0;
-    --statblock-list-padding-bottom: 0;
-    --statblock-list-spacing: 0.075em;
-    --statblock-list-style-type: disc;
-    --statblock-list-text-align: -webkit-match-parent;
-    --statblock-upper-level-padding: 2em;
-    --statblock-upper-level-margin: 2em;
-}
-.statblock.basic-pathfinder-2e-layouthaz .bar {
-    height: 1px;
-    background: var(--statblock-bar-color);
-    border: var(--statblock-bar-border-size) solid
-        var(--statblock-bar-border-color);
-    z-index: 1;
-    width: fit-content;
-}
-.statblock.basic-pathfinder-2e-layouthaz .statblock-content {
-    font-family: var(--statblock-content-font);
-    font-size: var(--statblock-content-font-size);
-    color: var(--statblock-font-color);
-    background-color: var(--statblock-background-color);
-    padding: 0.5em;
-    border: var(--statblock-border-size) var(--statblock-border-color) solid;
-    box-shadow: var(--statblock-box-shadow-x-offset)
-        var(--statblock-box-shadow-y-offset) var(--statblock-box-shadow-blur)
-        var(--statblock-box-shadow-color);
-    margin: 0.5em 2px;
-    display: flex;
-    gap: 1rem;
-}
-.statblock.basic-pathfinder-2e-layouthaz .statblock-content .statblock-detached {
-    position: absolute;
-    top: -9999px;
-}
-.statblock.basic-pathfinder-2e-layouthaz .statblock-content .statblock-item-container {
-    margin: 0;
-    padding: 0;
-}
-.statblock.basic-pathfinder-2e-layouthaz .statblock-content .statblock-item-inline {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    align-content: flex-start;
-    align-items: baseline;
-    justify-content: flex-start;
-    margin: 0;
-    padding: 0;
-}
-.statblock.basic-pathfinder-2e-layouthaz .statblock-content > .column {
-    width: var(--statblock-column-width);
-}
-.statblock.basic-pathfinder-2e-layouthaz
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline) {
-}
-.statblock.basic-pathfinder-2e-layouthaz
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline):has(
-        .line,
-        .property
-    ) {
-    margin-block: 0.25rem;
-}
-.statblock.basic-pathfinder-2e-layouthaz
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline):has(
-        .line,
-        .property
-    ):last-child {
-    margin-bottom: 0;
-}
-.statblock.basic-pathfinder-2e-layouthaz
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline):has(.line.name) {
-    margin: 0;
-}
-.statblock.basic-pathfinder-2e-layouthaz
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline)
-    > :is(.property, .line:has(.property-name)) {
-    margin-left: 1em;
-}
-.statblock.basic-pathfinder-2e-layouthaz
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline)
-    > :is(.property, .line)
-    .property-name {
-    margin-left: -1em;
-}
-.statblock.basic-pathfinder-2e-layouthaz
-    .statblock-content
-    > .column
-    > .statblock-item-container:has(.tapered-rule) {
-    margin-block: 0.25rem;
-}
-.statblock.basic-pathfinder-2e-layouthaz
-    .statblock-content
-    > .column
-    > .statblock-item-inline:has(.name)
-    + .statblock-item-container:has(.tapered-rule) {
-    margin-top: 0;
-}
-.statblock.basic-pathfinder-2e-layouthaz
-    .statblock-content
-    > .column
-    > .statblock-item-inline:has(
-        .rare_01,
-        .rare_02,
-        .rare_03,
-        .rare_04,
-        .alignment,
-        .size,
-        .xp,
-        .kingdom_xp,
-        .trait_01,
-        .trait_02,
-        .trait_03,
-        .trait_04,
-        .trait_05,
-        .trait_06,
-        .trait_07
-    ) {
-    row-gap: var(--statblock-traits-gap);
-    margin-bottom: 0.5em;
-}
-.statblock.basic-pathfinder-2e-layouthaz
-    .statblock-content
-    > .column
-    > .statblock-item-container:has(.effect) {
-    margin-left: 1em;
-}
+  .statblock.basic-pathfinder-2e-layout .statblock-content > :global(.column) {
+    width: 75vw;
+  }
+}
+.statblock.basic-pathfinder-2e-layout .spell-line .spells {
+  font-style: var(--statblock-spells-font-style);
+}
+.statblock.basic-pathfinder-2e-layout .statblock-table-header {
+  font-weight: var(--statblock-table-header-font-weight);
+}
+.statblock.basic-pathfinder-2e-layout .table {
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.statblock.basic-pathfinder-2e-layout .table-item {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-flow: column nowrap;
+}
+
 @media screen and (max-width: 400px) {
-    .statblock.basic-pathfinder-2e-layouthaz .statblock-content > :global(.column) {
-        width: 75vw;
-    }
+  .statblock.pathfinder-2e-action-layout .statblock-content > :global(.column) {
+    width: 75vw;
+  }
 }
-.statblock.basic-pathfinder-2e-layouthaz .dice-roller-result {
-    font-weight: var(--statblock-font-weight);
+.statblock.pathfinder-2e-action-layout .spell-line .spells {
+  font-style: var(--statblock-spells-font-style);
 }
-.statblock.basic-pathfinder-2e-layouthaz .roller-result {
-    font-weight: var(--statblock-font-weight);
+.statblock.pathfinder-2e-action-layout .statblock-table-header {
+  font-weight: var(--statblock-table-header-font-weight);
 }
-.statblock.basic-pathfinder-2e-layouthaz .image {
-    width: var(--statblock-image-width);
-    height: var(--statblock-image-height);
+.statblock.pathfinder-2e-action-layout .table {
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+  flex-wrap: wrap;
 }
-.statblock.basic-pathfinder-2e-layouthaz .image.pointer {
-    cursor: pointer;
+.statblock.pathfinder-2e-action-layout .table-item {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-flow: column nowrap;
 }
-.statblock.basic-pathfinder-2e-layouthaz .image img {
-    object-fit: cover;
-    width: 100%;
-    height: 100%;
-    border-radius: 100%;
-    border: var(--statblock-image-border-size) solid
-        var(--statblock-image-border-color);
-    object-position: center;
-}
-.statblock.basic-pathfinder-2e-layouthaz .line {
-    line-height: var(--statblock-property-line-height);
-    display: block;
-    color: var(--statblock-property-line-font-color);
-}
-.statblock.basic-pathfinder-2e-layouthaz .statblock-rendered-text-content {
-    color: var(--statblock-property-name-font-color);
-    font-weight: var(--statblock-property-name-font-weight);
-}
-.statblock.basic-pathfinder-2e-layouthaz .statblock-markdown,
-.statblock.basic-pathfinder-2e-layouthaz .property {
-    line-height: var(--statblock-property-line-height);
-}
-.statblock.basic-pathfinder-2e-layouthaz div.tapered-rule {
-    width: auto;
-    margin: 0;
-    height: 1px;
-    background: var(--statblock-bar-color);
-    clip-path: unset !important;
-    -webkit-clip-path: unset;
-}
-.statblock.basic-pathfinder-2e-layouthaz .flex-container {
-    align-items: center;
-    display: flex;
-    justify-content: space-between;
-}
-.statblock.basic-pathfinder-2e-layouthaz .heading {
-    align-items: center;
-    color: var(--statblock-heading-font-color);
-    display: flex;
-    font-family: var(--statblock-heading-font);
-    font-variant: var(--statblock-heading-font-variant);
-    font-weight: var(--statblock-heading-font-weight);
-    justify-content: space-between;
-    line-height: var(--statblock-heading-line-height);
-    letter-spacing: 1px;
-    margin: 0;
-}
-.statblock.basic-pathfinder-2e-layouthaz h1.section-header {
-    border: none;
-    color: var(--statblock-section-heading-font-color);
-    font-size: var(--statblock-section-heading-font-size);
-    font-variant: var(--statblock-section-heading-font-variant);
-    font-weight: var(--statblock-section-heading-font-weight);
-    letter-spacing: 1px;
-    margin: 0;
-    margin-bottom: 0.3em;
-    break-inside: avoid-column;
-    break-after: avoid-column;
-}
-.statblock.basic-pathfinder-2e-layouthaz h2.section-header {
-    border: none;
-    color: var(--statblock-section-heading-font-color);
-    font-size: var(--statblock-section-heading-font-size);
-    font-variant: var(--statblock-section-heading-font-variant);
-    font-weight: var(--statblock-section-heading-font-weight);
-    letter-spacing: 1px;
-    margin: 0;
-    margin-bottom: 0.3em;
-    break-inside: avoid-column;
-    break-after: avoid-column;
-}
-.statblock.basic-pathfinder-2e-layouthaz h3.section-header {
-    border: none;
-    color: var(--statblock-section-heading-font-color);
-    font-size: var(--statblock-section-heading-font-size);
-    font-variant: var(--statblock-section-heading-font-variant);
-    font-weight: var(--statblock-section-heading-font-weight);
-    letter-spacing: 1px;
-    margin: 0;
-    margin-bottom: 0;
-    break-inside: avoid-column;
-    break-after: avoid-column;
-    display: none;
-}
-.statblock.basic-pathfinder-2e-layouthaz .spell-line .spells {
-    font-style: var(--statblock-spells-font-style);
-}
-.statblock.basic-pathfinder-2e-layouthaz .statblock-table-header {
-    font-weight: var(--statblock-table-header-font-weight);
-}
-.statblock.basic-pathfinder-2e-layouthaz .table {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: center;
-    flex-wrap: wrap;
-}
-.statblock.basic-pathfinder-2e-layouthaz .table-item {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    flex-flow: column nowrap;
-}
-.statblock.basic-pathfinder-2e-layouthaz .traits {
-    margin: 0 0.25em 0 0;
-    display: inline;
-    font-weight: var(--statblock-traits-font-weight) !important;
-    font-style: var(--statblock-traits-font-style) !important;
-}
-.statblock.basic-pathfinder-2e-layouthaz .rare_01 {
-    background-color: var(--statblock-color-common) !important;
-}
-.statblock.basic-pathfinder-2e-layouthaz .rare_02 {
-    background-color: var(--statblock-color-uncommon) !important;
-}
-.statblock.basic-pathfinder-2e-layouthaz .rare_03 {
-    background-color: var(--statblock-color-rare) !important;
-}
-.statblock.basic-pathfinder-2e-layouthaz .rare_04 {
-    background-color: var(--statblock-color-unique) !important;
-}
-.statblock.basic-pathfinder-2e-layouthaz .alignment {
-    background-color: var(--statblock-color-alignment) !important;
-}
-.statblock.basic-pathfinder-2e-layouthaz .size {
-    background-color: var(--statblock-color-size) !important;
-}
-.statblock.basic-pathfinder-2e-layouthaz .xp,
-.statblock.basic-pathfinder-2e-layouthaz .kingdom_xp,
-.statblock.basic-pathfinder-2e-layouthaz .trait_01,
-.statblock.basic-pathfinder-2e-layouthaz .trait_02,
-.statblock.basic-pathfinder-2e-layouthaz .trait_03,
-.statblock.basic-pathfinder-2e-layouthaz .trait_04,
-.statblock.basic-pathfinder-2e-layouthaz .trait_05,
-.statblock.basic-pathfinder-2e-layouthaz .trait_06,
-.statblock.basic-pathfinder-2e-layouthaz .trait_07 {
-    background-color: var(--statblock-color-trait) !important;
-}
-.statblock.basic-pathfinder-2e-layouthaz .rare_01,
-.statblock.basic-pathfinder-2e-layouthaz .rare_02,
-.statblock.basic-pathfinder-2e-layouthaz .rare_03,
-.statblock.basic-pathfinder-2e-layouthaz .rare_04,
-.statblock.basic-pathfinder-2e-layouthaz .alignment,
-.statblock.basic-pathfinder-2e-layouthaz .size,
-.statblock.basic-pathfinder-2e-layouthaz .xp,
-.statblock.basic-pathfinder-2e-layouthaz .kingdom_xp,
-.statblock.basic-pathfinder-2e-layouthaz .trait_01,
-.statblock.basic-pathfinder-2e-layouthaz .trait_02,
-.statblock.basic-pathfinder-2e-layouthaz .trait_03,
-.statblock.basic-pathfinder-2e-layouthaz .trait_04,
-.statblock.basic-pathfinder-2e-layouthaz .trait_05,
-.statblock.basic-pathfinder-2e-layouthaz .trait_06,
-.statblock.basic-pathfinder-2e-layouthaz .trait_07 {
-    color: var(--statblock-traits-font-color) !important;
-    font-size: var(--statblock-traits-font-size);
-    font-style: var(--statblock-traits-font-style) !important;
-    font-weight: var(--statblock-traits-font-weight) !important;
-    letter-spacing: var(--statblock-traits-letter-spacing);
-    min-width: var(--statblock-traits-min-width);
-    margin: var(--statblock-traits-margins);
-    padding: var(--statblock-traits-padding);
-    text-align: var(--statblock-traits-text-align);
-    text-transform: var(--statblock-traits-text-transform);
-}
-.statblock.basic-pathfinder-2e-layouthaz .rare_01 span.property-name,
-.statblock.basic-pathfinder-2e-layouthaz .rare_02 span.property-name,
-.statblock.basic-pathfinder-2e-layouthaz .rare_03 span.property-name,
-.statblock.basic-pathfinder-2e-layouthaz .rare_04 span.property-name,
-.statblock.basic-pathfinder-2e-layouthaz .alignment span.property-name,
-.statblock.basic-pathfinder-2e-layouthaz .size span.property-name,
-.statblock.basic-pathfinder-2e-layouthaz .xp span.property-name,
-.statblock.basic-pathfinder-2e-layouthaz .kingdom_xp span.property-name,
-.statblock.basic-pathfinder-2e-layouthaz .trait_01 span.property-name,
-.statblock.basic-pathfinder-2e-layouthaz .trait_02 span.property-name,
-.statblock.basic-pathfinder-2e-layouthaz .trait_03 span.property-name,
-.statblock.basic-pathfinder-2e-layouthaz .trait_04 span.property-name,
-.statblock.basic-pathfinder-2e-layouthaz .trait_05 span.property-name,
-.statblock.basic-pathfinder-2e-layouthaz .trait_06 span.property-name,
-.statblock.basic-pathfinder-2e-layouthaz .trait_07 span.property-name {
-    display: none;
-}
-.statblock.basic-pathfinder-2e-layouthaz h3,
-.statblock.basic-pathfinder-2e-layouthaz .markdown-rendered h3,
-.statblock.basic-pathfinder-2e-layouthaz .HyperMD-header-3,
-.statblock.basic-pathfinder-2e-layouthaz .inline-title[data-level="3"],
-.statblock.basic-pathfinder-2e-layouthaz .HyperMD-list-line .cm-header-3 {
-    font-variant: var(--statblock-h3-variant);
-    letter-spacing: var(--statblock-h3-letter-spacing);
-    line-height: var(--statblock-h3-line-height);
-    font-size: var(--statblock-h3-size);
-    color: var(--statblock-h3-color);
-}
-.statblock.basic-pathfinder-2e-layouthaz a,
-.statblock.basic-pathfinder-2e-layouthaz a:-webkit-any-link,
-.statblock.basic-pathfinder-2e-layouthaz a.internal-link {
-    color: var(--statblock-hyperlink-color);
-    font-weight: bolder;
-    text-decoration: var(--statblock-hyperlink-text-decoration);
-}
-.statblock.basic-pathfinder-2e-layouthaz b,
-.statblock.basic-pathfinder-2e-layouthaz strong,
-.statblock.basic-pathfinder-2e-layouthaz .cm-strong {
-    font-weight: var(--statblock-property-name-font-weight);
-    color: var(--statblock-property-name-font-color);
-}
-.statblock.basic-pathfinder-2e-layouthaz i,
-.statblock.basic-pathfinder-2e-layouthaz em,
-.statblock.basic-pathfinder-2e-layouthaz .cm-em {
-    font-style: italic;
-    color: var(--statblock-italic-font-color);
-    font-weight: 500;
-}
-.statblock.basic-pathfinder-2e-layouthaz
-    .statblock-item-inline:has(.statblock-inline-item .name) {
-    display: flex;
-    flex-direction: row;
-    margin-inline: 0.25em;
-    gap: 0.25em;
-}
-.statblock.basic-pathfinder-2e-layouthaz
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item {
-}
-.statblock.basic-pathfinder-2e-layouthaz
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item:has(.name) {
-    flex: 1;
-}
-.statblock.basic-pathfinder-2e-layouthaz
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .name,
-.statblock.basic-pathfinder-2e-layouthaz
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .level {
-}
-.statblock.basic-pathfinder-2e-layouthaz
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .name
-    p,
-.statblock.basic-pathfinder-2e-layouthaz
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .level
-    p {
-    align-self: flex-start;
-    font-size: 1.2em;
-    font-weight: 900;
-    text-transform: uppercase;
-}
-.statblock.basic-pathfinder-2e-layouthaz
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .name
-    span.property-name,
-.statblock.basic-pathfinder-2e-layouthaz
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .level
-    span.property-name {
-    display: none;
-}
-.statblock.basic-pathfinder-2e-layouthaz
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .image {
-    width: unset;
-    height: unset;
-}
-.statblock.basic-pathfinder-2e-layouthaz
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    img {
-    width: unset;
-    height: var(--statblock-property-line-height);
-    border-radius: 0;
-    border: none;
-}
-.statblock.basic-pathfinder-2e-layouthaz ul {
-    display: block;
-    list-style-type: var(--statblock-list-style-type);
-    margin-block-start: var(--statblock-list-margin-block-start);
-    margin-block-end: var(--statblock-list-margin-block-end);
-    margin-inline-start: var(--statblock-list-margin-inline-start);
-    margin-inline-end: var(--statblock-list-margin-inline-end);
-    padding-inline-start: var(--statblock-list-padding-inline-start);
-}
-.statblock.basic-pathfinder-2e-layouthaz .markdown-rendered ul,
-.statblock.basic-pathfinder-2e-layouthaz .markdown-rendered ol {
-    padding-inline-start: var(--statblock-list-indent);
-}
-.statblock.basic-pathfinder-2e-layouthaz li {
-    color: var(--statblock-content-font);
-    display: list-item;
-    text-align: var(--statblock-list-text-align);
-}
-.statblock.basic-pathfinder-2e-layouthaz .markdown-source-view ol > li,
-.statblock.basic-pathfinder-2e-layouthaz .markdown-source-view ul > li,
-.statblock.basic-pathfinder-2e-layouthaz .markdown-preview-view ol > li,
-.statblock.basic-pathfinder-2e-layouthaz .markdown-preview-view ul > li,
-.statblock.basic-pathfinder-2e-layouthaz .markdown-rendered ul > li,
-.statblock.basic-pathfinder-2e-layouthaz .mod-cm6 .HyperMD-list-line.cm-line {
-    padding-top: var(--statblock-list-padding-top);
-    padding-bottom: var(--statblock-list-padding-bottom);
-}
-.statblock.basic-pathfinder-2e-layouthaz ol > li::marker,
-.statblock.basic-pathfinder-2e-layouthaz ul > li::marker,
-.statblock.basic-pathfinder-2e-layouthaz .cm-s-obsidian .cm-formatting-list {
-    color: var(--list-marker-color);
-}
-.statblock.basic-pathfinder-2e-layouthaz ::marker {
-    unicode-bidi: isolate;
-    font-variant-numeric: tabular-nums;
-    text-transform: none;
-    text-indent: 0;
-    text-align: start;
-    text-align-last: start;
-}
-.statblock.basic-pathfinder-2e-layoutinf {
-    --statblock-color-common: rgb(54, 69, 79);
-    --statblock-color-uncommon: rgb(143, 85, 66);
-    --statblock-color-rare: rgb(11, 37, 96);
-    --statblock-color-unique: rgb(77, 27, 106);
-    --statblock-color-alignment: rgb(89, 98, 143);
-    --statblock-color-size: rgb(75, 122, 92);
-    --statblock-color-trait: rgb(86, 12, 6);
-    --statblock-primary-color: rgb(51, 51, 51);
-    --statblock-rule-color: rgb(51, 51, 51);
-    --statblock-background-color: rgb(246, 244, 242);
-    --statblock-background-color-alt: rgb(229, 224, 219);
-    --statblock-bar-color: var(--statblock-rule-color);
-    --statblock-bar-border-size: 1px;
-    --statblock-bar-border-color: var(--statblock-rule-color);
-    --statblock-image-width: 75px;
-    --statblock-image-height: 75px;
-    --statblock-image-border-size: 2px;
-    --statblock-image-border-color: rgb(51, 51, 51);
-    --statblock-border-size: 1px;
-    --statblock-border-color: rgb(51, 51, 51);
-    --statblock-box-shadow-color: rgb(255, 215, 0);
-    --statblock-box-shadow-x-offset: 0;
-    --statblock-box-shadow-y-offset: 0;
-    --statblock-box-shadow-blur: 1.5em;
-    --statblock-font-color: var(--statblock-primary-color);
-    --statblock-font-weight: 400;
-    --statblock-content-font: system-ui, "Pathfinder", -apple-system,
-        BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-        "Open Sans", "Helvetica Neue", sans-serif;
-    --statblock-content-font-size: 13px;
-    --statblock-heading-font: system-ui, "Pathfinder", -apple-system,
-        BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-        "Open Sans", "Helvetica Neue", sans-serif;
-    --statblock-heading-font-color: var(--statblock-font-color);
-    --statblock-heading-font-size: 1.35em;
-    --statblock-heading-font-variant: small-caps;
-    --statblock-heading-font-weight: 700;
-    --statblock-heading-line-height: 1;
-    --statblock-property-line-height: 1.33em;
-    --statblock-property-font-color: var(--statblock-font-color);
-    --statblock-property-name-font-color: var(--statblock-font-color);
-    --statblock-property-name-font-weight: bold;
-    --statblock-section-heading-border-size: 1px;
-    --statblock-section-heading-border-color: transparent;
-    --statblock-section-heading-font-color: var(--statblock-font-color);
-    --statblock-section-heading-font-size: 1.33 empx;
-    --statblock-section-heading-font-variant: small-caps;
-    --statblock-section-heading-font-weight: 400;
-    --statblock-saves-line-height: 1.33em;
-    --statblock-spells-font-style: italic;
-    --statblock-table-header-font-weight: bold;
-    --statblock-other-font: system-ui, "Pathfinder", -apple-system,
-        BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-        "Open Sans", "Helvetica Neue", sans-serif;
-    --statblock-traits-font: system-ui, "Pathfinder", -apple-system,
-        BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-        "Open Sans", "Helvetica Neue", sans-serif;
-    --statblock-text-normal: rgb(--color-base-100);
-    --statblock-text-muted: rgb(--color-base-50);
-    --statblock-text-faint: rgba(--statblock-primary-color, 0.5);
-    --statblock-hyperlink-color: rgb(61, 102, 142);
-    --statblock-hyperlink-text-decoration: rgb(51, 51, 51) underline solid;
-    --statblock-hyperlink-text-shadow: 0.5px 0.5px 0.5px rgba(61, 102, 142);
-    --statblock-italic-font-color: rgb(77, 27, 105);
-    --statblock-h3-variant: small-caps;
-    --statblock-h3-letter-spacing: 1;
-    --statblock-h3-line-height: 1.33em;
-    --statblock-h3-size: 13px;
-    --statblock-h3-color: rgb(51, 51, 51);
-    --statblock-h3-weight: 400;
-    --statblock-h3-font-style: normal;
-    --statblock-h3-font-family: system-ui, "Pathfinder", -apple-system,
-        BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-        "Open Sans", "Helvetica Neue", sans-serif;
-    --statblock-column-width: 400px;
-    --statblock-column2-width: 1000px;
-    --statblock-traits-box-sizing: border-box;
-    --statblock-traits-font-color: rgb(255, 255, 255);
-    --statblock-traits-letter-spacing: 0.01em;
-    --statblock-traits-gap: 2px;
-    --statblock-traits-margins: 0 var(--statblock-traits-gap) 0 0;
-    --statblock-traits-min-width: 4em;
-    --statblock-traits-padding: 0.4em 1.1em 0.2em;
-    --statblock-traits-text-align: center;
-    --statblock-traits-text-transform: uppercase;
-    --statblock-traits-font-size: 12px;
-    --statblock-traits-font-style: normal;
-    --statblock-traits-font-weight: 900;
-    --statblock-list-bullet-border: none;
-    --statblock-list-bullet-radius: 50%;
-    --statblock-list-bullet-size: 0.3em;
-    --statblock-list-bullet-transform: none;
-    --statblock-list-numbered-style: decimal;
-    --statblock-list-indent: 2em;
-    --statblock-list-margin-block-start: 1em;
-    --statblock-list-margin-block-end: 1em;
-    --statblock-list-margin-inline-start: 0px;
-    --statblock-list-margin-inline-end: 0px;
-    --statblock-list-marker-color: blue;
-    --statblock-list-marker-color-collapsed: var(--text-accent);
-    --statblock-list-marker-color-hover: var(--text-muted);
-    --statblock-list-padding-inline-start: 40px;
-    --statblock-list-padding-top: 0;
-    --statblock-list-padding-bottom: 0;
-    --statblock-list-spacing: 0.075em;
-    --statblock-list-style-type: disc;
-    --statblock-list-text-align: -webkit-match-parent;
-    --statblock-upper-level-padding: 2em;
-    --statblock-upper-level-margin: 2em;
-}
-.statblock.basic-pathfinder-2e-layoutinf .bar {
-    height: 1px;
-    background: var(--statblock-bar-color);
-    border: var(--statblock-bar-border-size) solid
-        var(--statblock-bar-border-color);
-    z-index: 1;
-    width: fit-content;
-}
-.statblock.basic-pathfinder-2e-layoutinf .statblock-content {
-    font-family: var(--statblock-content-font);
-    font-size: var(--statblock-content-font-size);
-    color: var(--statblock-font-color);
-    background-color: var(--statblock-background-color);
-    padding: 0.5em;
-    border: var(--statblock-border-size) var(--statblock-border-color) solid;
-    box-shadow: var(--statblock-box-shadow-x-offset)
-        var(--statblock-box-shadow-y-offset) var(--statblock-box-shadow-blur)
-        var(--statblock-box-shadow-color);
-    margin: 0.5em 2px;
-    display: flex;
-    gap: 1rem;
-}
-.statblock.basic-pathfinder-2e-layoutinf .statblock-content .statblock-detached {
-    position: absolute;
-    top: -9999px;
-}
-.statblock.basic-pathfinder-2e-layoutinf .statblock-content .statblock-item-container {
-    margin: 0;
-    padding: 0;
-}
-.statblock.basic-pathfinder-2e-layoutinf .statblock-content .statblock-item-inline {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    align-content: flex-start;
-    align-items: baseline;
-    justify-content: flex-start;
-    margin: 0;
-    padding: 0;
-}
-.statblock.basic-pathfinder-2e-layoutinf .statblock-content > .column {
-    width: var(--statblock-column-width);
-}
-.statblock.basic-pathfinder-2e-layoutinf
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline) {
-}
-.statblock.basic-pathfinder-2e-layoutinf
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline):has(
-        .line,
-        .property
-    ) {
-    margin-block: 0.25rem;
-}
-.statblock.basic-pathfinder-2e-layoutinf
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline):has(
-        .line,
-        .property
-    ):last-child {
-    margin-bottom: 0;
-}
-.statblock.basic-pathfinder-2e-layoutinf
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline):has(.line.name) {
-    margin: 0;
-}
-.statblock.basic-pathfinder-2e-layoutinf
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline)
-    > :is(.property, .line:has(.property-name)) {
-    margin-left: 1em;
-}
-.statblock.basic-pathfinder-2e-layoutinf
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline)
-    > :is(.property, .line)
-    .property-name {
-    margin-left: -1em;
-}
-.statblock.basic-pathfinder-2e-layoutinf
-    .statblock-content
-    > .column
-    > .statblock-item-container:has(.tapered-rule) {
-    margin-block: 0.25rem;
-}
-.statblock.basic-pathfinder-2e-layoutinf
-    .statblock-content
-    > .column
-    > .statblock-item-inline:has(.name)
-    + .statblock-item-container:has(.tapered-rule) {
-    margin-top: 0;
-}
-.statblock.basic-pathfinder-2e-layoutinf
-    .statblock-content
-    > .column
-    > .statblock-item-inline:has(
-        .rare_01,
-        .rare_02,
-        .rare_03,
-        .rare_04,
-        .alignment,
-        .size,
-        .xp,
-        .kingdom_xp,
-        .trait_01,
-        .trait_02,
-        .trait_03,
-        .trait_04,
-        .trait_05,
-        .trait_06,
-        .trait_07
-    ) {
-    row-gap: var(--statblock-traits-gap);
-    margin-bottom: 0.5em;
-}
+
 @media screen and (max-width: 400px) {
-    .statblock.basic-pathfinder-2e-layoutinf .statblock-content > :global(.column) {
-        width: 75vw;
-    }
+  .statblock.pathfinder-2e-hazard-layout .statblock-content > :global(.column) {
+    width: 75vw;
+  }
 }
-.statblock.basic-pathfinder-2e-layoutinf .dice-roller-result {
-    font-weight: var(--statblock-font-weight);
+.statblock.pathfinder-2e-hazard-layout .spell-line .spells {
+  font-style: var(--statblock-spells-font-style);
 }
-.statblock.basic-pathfinder-2e-layoutinf .roller-result {
-    font-weight: var(--statblock-font-weight);
+.statblock.pathfinder-2e-hazard-layout .statblock-table-header {
+  font-weight: var(--statblock-table-header-font-weight);
 }
-.statblock.basic-pathfinder-2e-layoutinf .image {
-    width: var(--statblock-image-width);
-    height: var(--statblock-image-height);
+.statblock.pathfinder-2e-hazard-layout .table {
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+  flex-wrap: wrap;
 }
-.statblock.basic-pathfinder-2e-layoutinf .image.pointer {
-    cursor: pointer;
+.statblock.pathfinder-2e-hazard-layout .table-item {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-flow: column nowrap;
 }
-.statblock.basic-pathfinder-2e-layoutinf .image img {
-    object-fit: cover;
-    width: 100%;
-    height: 100%;
-    border-radius: 100%;
-    border: var(--statblock-image-border-size) solid
-        var(--statblock-image-border-color);
-    object-position: center;
-}
-.statblock.basic-pathfinder-2e-layoutinf .line {
-    line-height: var(--statblock-property-line-height);
-    display: block;
-    color: var(--statblock-property-line-font-color);
-}
-.statblock.basic-pathfinder-2e-layoutinf .statblock-rendered-text-content {
-    color: var(--statblock-property-name-font-color);
-    font-weight: var(--statblock-property-name-font-weight);
-}
-.statblock.basic-pathfinder-2e-layoutinf .statblock-markdown,
-.statblock.basic-pathfinder-2e-layoutinf .property {
-    line-height: var(--statblock-property-line-height);
-}
-.statblock.basic-pathfinder-2e-layoutinf div.tapered-rule {
-    width: auto;
-    margin: 0;
-    height: 1px;
-    background: var(--statblock-bar-color);
-    clip-path: unset !important;
-    -webkit-clip-path: unset;
-}
-.statblock.basic-pathfinder-2e-layoutinf .flex-container {
-    align-items: center;
-    display: flex;
-    justify-content: space-between;
-}
-.statblock.basic-pathfinder-2e-layoutinf .heading {
-    align-items: center;
-    color: var(--statblock-heading-font-color);
-    display: flex;
-    font-family: var(--statblock-heading-font);
-    font-variant: var(--statblock-heading-font-variant);
-    font-weight: var(--statblock-heading-font-weight);
-    justify-content: space-between;
-    line-height: var(--statblock-heading-line-height);
-    letter-spacing: 1px;
-    margin: 0;
-}
-.statblock.basic-pathfinder-2e-layoutinf h1.section-header {
-    border: none;
-    color: var(--statblock-section-heading-font-color);
-    font-size: var(--statblock-section-heading-font-size);
-    font-variant: var(--statblock-section-heading-font-variant);
-    font-weight: var(--statblock-section-heading-font-weight);
-    letter-spacing: 1px;
-    margin: 0;
-    margin-bottom: 0.3em;
-    break-inside: avoid-column;
-    break-after: avoid-column;
-}
-.statblock.basic-pathfinder-2e-layoutinf h2.section-header {
-    border: none;
-    color: var(--statblock-section-heading-font-color);
-    font-size: var(--statblock-section-heading-font-size);
-    font-variant: var(--statblock-section-heading-font-variant);
-    font-weight: var(--statblock-section-heading-font-weight);
-    letter-spacing: 1px;
-    margin: 0;
-    margin-bottom: 0.3em;
-    break-inside: avoid-column;
-    break-after: avoid-column;
-}
-.statblock.basic-pathfinder-2e-layoutinf h3.section-header {
-    border: none;
-    color: var(--statblock-section-heading-font-color);
-    font-size: var(--statblock-section-heading-font-size);
-    font-variant: var(--statblock-section-heading-font-variant);
-    font-weight: var(--statblock-section-heading-font-weight);
-    letter-spacing: 1px;
-    margin: 0;
-    margin-bottom: 0;
-    break-inside: avoid-column;
-    break-after: avoid-column;
-    display: none;
-}
-.statblock.basic-pathfinder-2e-layoutinf .spell-line .spells {
-    font-style: var(--statblock-spells-font-style);
-}
-.statblock.basic-pathfinder-2e-layoutinf .statblock-table-header {
-    font-weight: var(--statblock-table-header-font-weight);
-}
-.statblock.basic-pathfinder-2e-layoutinf .table {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: center;
-    flex-wrap: wrap;
-}
-.statblock.basic-pathfinder-2e-layoutinf .table-item {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    flex-flow: column nowrap;
-}
-.statblock.basic-pathfinder-2e-layoutinf .traits {
-    margin: 0 0.25em 0 0;
-    display: inline;
-    font-weight: var(--statblock-traits-font-weight) !important;
-    font-style: var(--statblock-traits-font-style) !important;
-}
-.statblock.basic-pathfinder-2e-layoutinf .rare_01 {
-    background-color: var(--statblock-color-common) !important;
-}
-.statblock.basic-pathfinder-2e-layoutinf .rare_02 {
-    background-color: var(--statblock-color-uncommon) !important;
-}
-.statblock.basic-pathfinder-2e-layoutinf .rare_03 {
-    background-color: var(--statblock-color-rare) !important;
-}
-.statblock.basic-pathfinder-2e-layoutinf .rare_04 {
-    background-color: var(--statblock-color-unique) !important;
-}
-.statblock.basic-pathfinder-2e-layoutinf .alignment {
-    background-color: var(--statblock-color-alignment) !important;
-}
-.statblock.basic-pathfinder-2e-layoutinf .size {
-    background-color: var(--statblock-color-size) !important;
-}
-.statblock.basic-pathfinder-2e-layoutinf .xp,
-.statblock.basic-pathfinder-2e-layoutinf .kingdom_xp,
-.statblock.basic-pathfinder-2e-layoutinf .trait_01,
-.statblock.basic-pathfinder-2e-layoutinf .trait_02,
-.statblock.basic-pathfinder-2e-layoutinf .trait_03,
-.statblock.basic-pathfinder-2e-layoutinf .trait_04,
-.statblock.basic-pathfinder-2e-layoutinf .trait_05,
-.statblock.basic-pathfinder-2e-layoutinf .trait_06,
-.statblock.basic-pathfinder-2e-layoutinf .trait_07 {
-    background-color: var(--statblock-color-trait) !important;
-}
-.statblock.basic-pathfinder-2e-layoutinf .rare_01,
-.statblock.basic-pathfinder-2e-layoutinf .rare_02,
-.statblock.basic-pathfinder-2e-layoutinf .rare_03,
-.statblock.basic-pathfinder-2e-layoutinf .rare_04,
-.statblock.basic-pathfinder-2e-layoutinf .alignment,
-.statblock.basic-pathfinder-2e-layoutinf .size,
-.statblock.basic-pathfinder-2e-layoutinf .xp,
-.statblock.basic-pathfinder-2e-layoutinf .kingdom_xp,
-.statblock.basic-pathfinder-2e-layoutinf .trait_01,
-.statblock.basic-pathfinder-2e-layoutinf .trait_02,
-.statblock.basic-pathfinder-2e-layoutinf .trait_03,
-.statblock.basic-pathfinder-2e-layoutinf .trait_04,
-.statblock.basic-pathfinder-2e-layoutinf .trait_05,
-.statblock.basic-pathfinder-2e-layoutinf .trait_06,
-.statblock.basic-pathfinder-2e-layoutinf .trait_07 {
-    color: var(--statblock-traits-font-color) !important;
-    font-size: var(--statblock-traits-font-size);
-    font-style: var(--statblock-traits-font-style) !important;
-    font-weight: var(--statblock-traits-font-weight) !important;
-    letter-spacing: var(--statblock-traits-letter-spacing);
-    min-width: var(--statblock-traits-min-width);
-    margin: var(--statblock-traits-margins);
-    padding: var(--statblock-traits-padding);
-    text-align: var(--statblock-traits-text-align);
-    text-transform: var(--statblock-traits-text-transform);
-}
-.statblock.basic-pathfinder-2e-layoutinf .rare_01 span.property-name,
-.statblock.basic-pathfinder-2e-layoutinf .rare_02 span.property-name,
-.statblock.basic-pathfinder-2e-layoutinf .rare_03 span.property-name,
-.statblock.basic-pathfinder-2e-layoutinf .rare_04 span.property-name,
-.statblock.basic-pathfinder-2e-layoutinf .alignment span.property-name,
-.statblock.basic-pathfinder-2e-layoutinf .size span.property-name,
-.statblock.basic-pathfinder-2e-layoutinf .xp span.property-name,
-.statblock.basic-pathfinder-2e-layoutinf .kingdom_xp span.property-name,
-.statblock.basic-pathfinder-2e-layoutinf .trait_01 span.property-name,
-.statblock.basic-pathfinder-2e-layoutinf .trait_02 span.property-name,
-.statblock.basic-pathfinder-2e-layoutinf .trait_03 span.property-name,
-.statblock.basic-pathfinder-2e-layoutinf .trait_04 span.property-name,
-.statblock.basic-pathfinder-2e-layoutinf .trait_05 span.property-name,
-.statblock.basic-pathfinder-2e-layoutinf .trait_06 span.property-name,
-.statblock.basic-pathfinder-2e-layoutinf .trait_07 span.property-name {
-    display: none;
-}
-.statblock.basic-pathfinder-2e-layoutinf h3,
-.statblock.basic-pathfinder-2e-layoutinf .markdown-rendered h3,
-.statblock.basic-pathfinder-2e-layoutinf .HyperMD-header-3,
-.statblock.basic-pathfinder-2e-layoutinf .inline-title[data-level="3"],
-.statblock.basic-pathfinder-2e-layoutinf .HyperMD-list-line .cm-header-3 {
-    font-variant: var(--statblock-h3-variant);
-    letter-spacing: var(--statblock-h3-letter-spacing);
-    line-height: var(--statblock-h3-line-height);
-    font-size: var(--statblock-h3-size);
-    color: var(--statblock-h3-color);
-}
-.statblock.basic-pathfinder-2e-layoutinf a,
-.statblock.basic-pathfinder-2e-layoutinf a:-webkit-any-link,
-.statblock.basic-pathfinder-2e-layoutinf a.internal-link {
-    color: var(--statblock-hyperlink-color);
-    font-weight: bolder;
-    text-decoration: var(--statblock-hyperlink-text-decoration);
-}
-.statblock.basic-pathfinder-2e-layoutinf b,
-.statblock.basic-pathfinder-2e-layoutinf strong,
-.statblock.basic-pathfinder-2e-layoutinf .cm-strong {
-    font-weight: var(--statblock-property-name-font-weight);
-    color: var(--statblock-property-name-font-color);
-}
-.statblock.basic-pathfinder-2e-layoutinf i,
-.statblock.basic-pathfinder-2e-layoutinf em,
-.statblock.basic-pathfinder-2e-layoutinf .cm-em {
-    font-style: italic;
-    color: var(--statblock-italic-font-color);
-    font-weight: 500;
-}
-.statblock.basic-pathfinder-2e-layoutinf
-    .statblock-item-inline:has(.statblock-inline-item .name) {
-    display: flex;
-    flex-direction: row;
-    margin-inline: 0.25em;
-    gap: 0.25em;
-}
-.statblock.basic-pathfinder-2e-layoutinf
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item {
-}
-.statblock.basic-pathfinder-2e-layoutinf
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item:has(.name) {
-    flex: 1;
-}
-.statblock.basic-pathfinder-2e-layoutinf
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .name,
-.statblock.basic-pathfinder-2e-layoutinf
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .level {
-}
-.statblock.basic-pathfinder-2e-layoutinf
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .name
-    p,
-.statblock.basic-pathfinder-2e-layoutinf
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .level
-    p {
-    align-self: flex-start;
-    font-size: 1.2em;
-    font-weight: 900;
-    text-transform: uppercase;
-}
-.statblock.basic-pathfinder-2e-layoutinf
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .name
-    span.property-name,
-.statblock.basic-pathfinder-2e-layoutinf
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .level
-    span.property-name {
-    display: none;
-}
-.statblock.basic-pathfinder-2e-layoutinf
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .image {
-    width: unset;
-    height: unset;
-}
-.statblock.basic-pathfinder-2e-layoutinf
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    img {
-    width: unset;
-    height: var(--statblock-property-line-height);
-    border-radius: 0;
-    border: none;
-}
-.statblock.basic-pathfinder-2e-layoutinf ul {
-    display: block;
-    list-style-type: var(--statblock-list-style-type);
-    margin-block-start: var(--statblock-list-margin-block-start);
-    margin-block-end: var(--statblock-list-margin-block-end);
-    margin-inline-start: var(--statblock-list-margin-inline-start);
-    margin-inline-end: var(--statblock-list-margin-inline-end);
-    padding-inline-start: var(--statblock-list-padding-inline-start);
-}
-.statblock.basic-pathfinder-2e-layoutinf .markdown-rendered ul,
-.statblock.basic-pathfinder-2e-layoutinf .markdown-rendered ol {
-    padding-inline-start: var(--statblock-list-indent);
-}
-.statblock.basic-pathfinder-2e-layoutinf li {
-    color: var(--statblock-content-font);
-    display: list-item;
-    text-align: var(--statblock-list-text-align);
-}
-.statblock.basic-pathfinder-2e-layoutinf .markdown-source-view ol > li,
-.statblock.basic-pathfinder-2e-layoutinf .markdown-source-view ul > li,
-.statblock.basic-pathfinder-2e-layoutinf .markdown-preview-view ol > li,
-.statblock.basic-pathfinder-2e-layoutinf .markdown-preview-view ul > li,
-.statblock.basic-pathfinder-2e-layoutinf .markdown-rendered ul > li,
-.statblock.basic-pathfinder-2e-layoutinf .mod-cm6 .HyperMD-list-line.cm-line {
-    padding-top: var(--statblock-list-padding-top);
-    padding-bottom: var(--statblock-list-padding-bottom);
-}
-.statblock.basic-pathfinder-2e-layoutinf ol > li::marker,
-.statblock.basic-pathfinder-2e-layoutinf ul > li::marker,
-.statblock.basic-pathfinder-2e-layoutinf .cm-s-obsidian .cm-formatting-list {
-    color: var(--list-marker-color);
-}
-.statblock.basic-pathfinder-2e-layoutinf ::marker {
-    unicode-bidi: isolate;
-    font-variant-numeric: tabular-nums;
-    text-transform: none;
-    text-indent: 0;
-    text-align: start;
-    text-align-last: start;
-}
-.statblock.basic-pathfinder-2e-layoutmisc {
-    --statblock-color-common: rgb(54, 69, 79);
-    --statblock-color-uncommon: rgb(143, 85, 66);
-    --statblock-color-rare: rgb(11, 37, 96);
-    --statblock-color-unique: rgb(77, 27, 106);
-    --statblock-color-alignment: rgb(89, 98, 143);
-    --statblock-color-size: rgb(75, 122, 92);
-    --statblock-color-trait: rgb(86, 12, 6);
-    --statblock-primary-color: rgb(51, 51, 51);
-    --statblock-rule-color: rgb(51, 51, 51);
-    --statblock-background-color: rgb(246, 244, 242);
-    --statblock-background-color-alt: rgb(229, 224, 219);
-    --statblock-bar-color: var(--statblock-rule-color);
-    --statblock-bar-border-size: 1px;
-    --statblock-bar-border-color: var(--statblock-rule-color);
-    --statblock-image-width: 75px;
-    --statblock-image-height: 75px;
-    --statblock-image-border-size: 2px;
-    --statblock-image-border-color: rgb(51, 51, 51);
-    --statblock-border-size: 1px;
-    --statblock-border-color: rgb(51, 51, 51);
-    --statblock-box-shadow-color: rgb(255, 215, 0);
-    --statblock-box-shadow-x-offset: 0;
-    --statblock-box-shadow-y-offset: 0;
-    --statblock-box-shadow-blur: 1.5em;
-    --statblock-font-color: var(--statblock-primary-color);
-    --statblock-font-weight: 400;
-    --statblock-content-font: system-ui, "Pathfinder", -apple-system,
-        BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-        "Open Sans", "Helvetica Neue", sans-serif;
-    --statblock-content-font-size: 13px;
-    --statblock-heading-font: system-ui, "Pathfinder", -apple-system,
-        BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-        "Open Sans", "Helvetica Neue", sans-serif;
-    --statblock-heading-font-color: var(--statblock-font-color);
-    --statblock-heading-font-size: 1.35em;
-    --statblock-heading-font-variant: small-caps;
-    --statblock-heading-font-weight: 700;
-    --statblock-heading-line-height: 1;
-    --statblock-property-line-height: 1.33em;
-    --statblock-property-font-color: var(--statblock-font-color);
-    --statblock-property-name-font-color: var(--statblock-font-color);
-    --statblock-property-name-font-weight: bold;
-    --statblock-section-heading-border-size: 1px;
-    --statblock-section-heading-border-color: transparent;
-    --statblock-section-heading-font-color: var(--statblock-font-color);
-    --statblock-section-heading-font-size: 1.33 empx;
-    --statblock-section-heading-font-variant: small-caps;
-    --statblock-section-heading-font-weight: 400;
-    --statblock-saves-line-height: 1.33em;
-    --statblock-spells-font-style: italic;
-    --statblock-table-header-font-weight: bold;
-    --statblock-other-font: system-ui, "Pathfinder", -apple-system,
-        BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-        "Open Sans", "Helvetica Neue", sans-serif;
-    --statblock-traits-font: system-ui, "Pathfinder", -apple-system,
-        BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-        "Open Sans", "Helvetica Neue", sans-serif;
-    --statblock-text-normal: rgb(--color-base-100);
-    --statblock-text-muted: rgb(--color-base-50);
-    --statblock-text-faint: rgba(--statblock-primary-color, 0.5);
-    --statblock-hyperlink-color: rgb(61, 102, 142);
-    --statblock-hyperlink-text-decoration: rgb(51, 51, 51) underline solid;
-    --statblock-hyperlink-text-shadow: 0.5px 0.5px 0.5px rgba(61, 102, 142);
-    --statblock-italic-font-color: rgb(77, 27, 105);
-    --statblock-h3-variant: small-caps;
-    --statblock-h3-letter-spacing: 1;
-    --statblock-h3-line-height: 1.33em;
-    --statblock-h3-size: 13px;
-    --statblock-h3-color: rgb(51, 51, 51);
-    --statblock-h3-weight: 400;
-    --statblock-h3-font-style: normal;
-    --statblock-h3-font-family: system-ui, "Pathfinder", -apple-system,
-        BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-        "Open Sans", "Helvetica Neue", sans-serif;
-    --statblock-column-width: 400px;
-    --statblock-column2-width: 1000px;
-    --statblock-traits-box-sizing: border-box;
-    --statblock-traits-font-color: rgb(255, 255, 255);
-    --statblock-traits-letter-spacing: 0.01em;
-    --statblock-traits-gap: 2px;
-    --statblock-traits-margins: 0 var(--statblock-traits-gap) 0 0;
-    --statblock-traits-min-width: 4em;
-    --statblock-traits-padding: 0.4em 1.1em 0.2em;
-    --statblock-traits-text-align: center;
-    --statblock-traits-text-transform: uppercase;
-    --statblock-traits-font-size: 12px;
-    --statblock-traits-font-style: normal;
-    --statblock-traits-font-weight: 900;
-    --statblock-list-bullet-border: none;
-    --statblock-list-bullet-radius: 50%;
-    --statblock-list-bullet-size: 0.3em;
-    --statblock-list-bullet-transform: none;
-    --statblock-list-numbered-style: decimal;
-    --statblock-list-indent: 2em;
-    --statblock-list-margin-block-start: 1em;
-    --statblock-list-margin-block-end: 1em;
-    --statblock-list-margin-inline-start: 0px;
-    --statblock-list-margin-inline-end: 0px;
-    --statblock-list-marker-color: blue;
-    --statblock-list-marker-color-collapsed: var(--text-accent);
-    --statblock-list-marker-color-hover: var(--text-muted);
-    --statblock-list-padding-inline-start: 40px;
-    --statblock-list-padding-top: 0;
-    --statblock-list-padding-bottom: 0;
-    --statblock-list-spacing: 0.075em;
-    --statblock-list-style-type: disc;
-    --statblock-list-text-align: -webkit-match-parent;
-    --statblock-upper-level-padding: 2em;
-    --statblock-upper-level-margin: 2em;
-}
-.statblock.basic-pathfinder-2e-layoutmisc .bar {
-    height: 1px;
-    background: var(--statblock-bar-color);
-    border: var(--statblock-bar-border-size) solid
-        var(--statblock-bar-border-color);
-    z-index: 1;
-    width: fit-content;
-}
-.statblock.basic-pathfinder-2e-layoutmisc .statblock-content {
-    font-family: var(--statblock-content-font);
-    font-size: var(--statblock-content-font-size);
-    color: var(--statblock-font-color);
-    background-color: var(--statblock-background-color);
-    padding: 0.5em;
-    border: var(--statblock-border-size) var(--statblock-border-color) solid;
-    box-shadow: var(--statblock-box-shadow-x-offset)
-        var(--statblock-box-shadow-y-offset) var(--statblock-box-shadow-blur)
-        var(--statblock-box-shadow-color);
-    margin: 0.5em 2px;
-    display: flex;
-    gap: 1rem;
-}
-.statblock.basic-pathfinder-2e-layoutmisc .statblock-content .statblock-detached {
-    position: absolute;
-    top: -9999px;
-}
-.statblock.basic-pathfinder-2e-layoutmisc .statblock-content .statblock-item-container {
-    margin: 0;
-    padding: 0;
-}
-.statblock.basic-pathfinder-2e-layoutmisc .statblock-content .statblock-item-inline {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    align-content: flex-start;
-    align-items: baseline;
-    justify-content: flex-start;
-    margin: 0;
-    padding: 0;
-}
-.statblock.basic-pathfinder-2e-layoutmisc .statblock-content > .column {
-    width: var(--statblock-column-width);
-}
-.statblock.basic-pathfinder-2e-layoutmisc
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline) {
-}
-.statblock.basic-pathfinder-2e-layoutmisc
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline):has(
-        .line,
-        .property
-    ) {
-    margin-block: 0.25rem;
-}
-.statblock.basic-pathfinder-2e-layoutmisc
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline):has(
-        .line,
-        .property
-    ):last-child {
-    margin-bottom: 0;
-}
-.statblock.basic-pathfinder-2e-layoutmisc
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline):has(.line.name) {
-    margin: 0;
-}
-.statblock.basic-pathfinder-2e-layoutmisc
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline)
-    > :is(.property, .line:has(.property-name)) {
-    margin-left: 1em;
-}
-.statblock.basic-pathfinder-2e-layoutmisc
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline)
-    > :is(.property, .line)
-    .property-name {
-    margin-left: -1em;
-}
-.statblock.basic-pathfinder-2e-layoutmisc
-    .statblock-content
-    > .column
-    > .statblock-item-container:has(.tapered-rule) {
-    margin-block: 0.25rem;
-}
-.statblock.basic-pathfinder-2e-layoutmisc
-    .statblock-content
-    > .column
-    > .statblock-item-inline:has(.name)
-    + .statblock-item-container:has(.tapered-rule) {
-    margin-top: 0;
-}
-.statblock.basic-pathfinder-2e-layoutmisc
-    .statblock-content
-    > .column
-    > .statblock-item-inline:has(
-        .rare_01,
-        .rare_02,
-        .rare_03,
-        .rare_04,
-        .alignment,
-        .size,
-        .xp,
-        .kingdom_xp,
-        .trait_01,
-        .trait_02,
-        .trait_03,
-        .trait_04,
-        .trait_05,
-        .trait_06,
-        .trait_07
-    ) {
-    row-gap: var(--statblock-traits-gap);
-    margin-bottom: 0.5em;
-}
+
 @media screen and (max-width: 400px) {
-    .statblock.basic-pathfinder-2e-layoutmisc .statblock-content > :global(.column) {
-        width: 75vw;
-    }
+  .statblock.pathfinder-2e-influence-layout .statblock-content > :global(.column) {
+    width: 75vw;
+  }
 }
-.statblock.basic-pathfinder-2e-layoutmisc .dice-roller-result {
-    font-weight: var(--statblock-font-weight);
+.statblock.pathfinder-2e-influence-layout .spell-line .spells {
+  font-style: var(--statblock-spells-font-style);
 }
-.statblock.basic-pathfinder-2e-layoutmisc .roller-result {
-    font-weight: var(--statblock-font-weight);
+.statblock.pathfinder-2e-influence-layout .statblock-table-header {
+  font-weight: var(--statblock-table-header-font-weight);
 }
-.statblock.basic-pathfinder-2e-layoutmisc .image {
-    width: var(--statblock-image-width);
-    height: var(--statblock-image-height);
+.statblock.pathfinder-2e-influence-layout .table {
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+  flex-wrap: wrap;
 }
-.statblock.basic-pathfinder-2e-layoutmisc .image.pointer {
-    cursor: pointer;
+.statblock.pathfinder-2e-influence-layout .table-item {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-flow: column nowrap;
 }
-.statblock.basic-pathfinder-2e-layoutmisc .image img {
-    object-fit: cover;
-    width: 100%;
-    height: 100%;
-    border-radius: 100%;
-    border: var(--statblock-image-border-size) solid
-        var(--statblock-image-border-color);
-    object-position: center;
-}
-.statblock.basic-pathfinder-2e-layoutmisc .line {
-    line-height: var(--statblock-property-line-height);
-    display: block;
-    color: var(--statblock-property-line-font-color);
-}
-.statblock.basic-pathfinder-2e-layoutmisc .statblock-rendered-text-content {
-    color: var(--statblock-property-name-font-color);
-    font-weight: var(--statblock-property-name-font-weight);
-}
-.statblock.basic-pathfinder-2e-layoutmisc .statblock-markdown,
-.statblock.basic-pathfinder-2e-layoutmisc .property {
-    line-height: var(--statblock-property-line-height);
-}
-.statblock.basic-pathfinder-2e-layoutmisc div.tapered-rule {
-    width: auto;
-    margin: 0;
-    height: 1px;
-    background: var(--statblock-bar-color);
-    clip-path: unset !important;
-    -webkit-clip-path: unset;
-}
-.statblock.basic-pathfinder-2e-layoutmisc .flex-container {
-    align-items: center;
-    display: flex;
-    justify-content: space-between;
-}
-.statblock.basic-pathfinder-2e-layoutmisc .heading {
-    align-items: center;
-    color: var(--statblock-heading-font-color);
-    display: flex;
-    font-family: var(--statblock-heading-font);
-    font-variant: var(--statblock-heading-font-variant);
-    font-weight: var(--statblock-heading-font-weight);
-    justify-content: space-between;
-    line-height: var(--statblock-heading-line-height);
-    letter-spacing: 1px;
-    margin: 0;
-}
-.statblock.basic-pathfinder-2e-layoutmisc h1.section-header {
-    border: none;
-    color: var(--statblock-section-heading-font-color);
-    font-size: var(--statblock-section-heading-font-size);
-    font-variant: var(--statblock-section-heading-font-variant);
-    font-weight: var(--statblock-section-heading-font-weight);
-    letter-spacing: 1px;
-    margin: 0;
-    margin-bottom: 0.3em;
-    break-inside: avoid-column;
-    break-after: avoid-column;
-}
-.statblock.basic-pathfinder-2e-layoutmisc h2.section-header {
-    border: none;
-    color: var(--statblock-section-heading-font-color);
-    font-size: var(--statblock-section-heading-font-size);
-    font-variant: var(--statblock-section-heading-font-variant);
-    font-weight: var(--statblock-section-heading-font-weight);
-    letter-spacing: 1px;
-    margin: 0;
-    margin-bottom: 0.3em;
-    break-inside: avoid-column;
-    break-after: avoid-column;
-}
-.statblock.basic-pathfinder-2e-layoutmisc h3.section-header {
-    border: none;
-    color: var(--statblock-section-heading-font-color);
-    font-size: var(--statblock-section-heading-font-size);
-    font-variant: var(--statblock-section-heading-font-variant);
-    font-weight: var(--statblock-section-heading-font-weight);
-    letter-spacing: 1px;
-    margin: 0;
-    margin-bottom: 0;
-    break-inside: avoid-column;
-    break-after: avoid-column;
-    display: none;
-}
-.statblock.basic-pathfinder-2e-layoutmisc .spell-line .spells {
-    font-style: var(--statblock-spells-font-style);
-}
-.statblock.basic-pathfinder-2e-layoutmisc .statblock-table-header {
-    font-weight: var(--statblock-table-header-font-weight);
-}
-.statblock.basic-pathfinder-2e-layoutmisc .table {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: center;
-    flex-wrap: wrap;
-}
-.statblock.basic-pathfinder-2e-layoutmisc .table-item {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    flex-flow: column nowrap;
-}
-.statblock.basic-pathfinder-2e-layoutmisc .traits {
-    margin: 0 0.25em 0 0;
-    display: inline;
-    font-weight: var(--statblock-traits-font-weight) !important;
-    font-style: var(--statblock-traits-font-style) !important;
-}
-.statblock.basic-pathfinder-2e-layoutmisc .rare_01 {
-    background-color: var(--statblock-color-common) !important;
-}
-.statblock.basic-pathfinder-2e-layoutmisc .rare_02 {
-    background-color: var(--statblock-color-uncommon) !important;
-}
-.statblock.basic-pathfinder-2e-layoutmisc .rare_03 {
-    background-color: var(--statblock-color-rare) !important;
-}
-.statblock.basic-pathfinder-2e-layoutmisc .rare_04 {
-    background-color: var(--statblock-color-unique) !important;
-}
-.statblock.basic-pathfinder-2e-layoutmisc .alignment {
-    background-color: var(--statblock-color-alignment) !important;
-}
-.statblock.basic-pathfinder-2e-layoutmisc .size {
-    background-color: var(--statblock-color-size) !important;
-}
-.statblock.basic-pathfinder-2e-layoutmisc .xp,
-.statblock.basic-pathfinder-2e-layoutmisc .kingdom_xp,
-.statblock.basic-pathfinder-2e-layoutmisc .trait_01,
-.statblock.basic-pathfinder-2e-layoutmisc .trait_02,
-.statblock.basic-pathfinder-2e-layoutmisc .trait_03,
-.statblock.basic-pathfinder-2e-layoutmisc .trait_04,
-.statblock.basic-pathfinder-2e-layoutmisc .trait_05,
-.statblock.basic-pathfinder-2e-layoutmisc .trait_06,
-.statblock.basic-pathfinder-2e-layoutmisc .trait_07 {
-    background-color: var(--statblock-color-trait) !important;
-}
-.statblock.basic-pathfinder-2e-layoutmisc .rare_01,
-.statblock.basic-pathfinder-2e-layoutmisc .rare_02,
-.statblock.basic-pathfinder-2e-layoutmisc .rare_03,
-.statblock.basic-pathfinder-2e-layoutmisc .rare_04,
-.statblock.basic-pathfinder-2e-layoutmisc .alignment,
-.statblock.basic-pathfinder-2e-layoutmisc .size,
-.statblock.basic-pathfinder-2e-layoutmisc .xp,
-.statblock.basic-pathfinder-2e-layoutmisc .kingdom_xp,
-.statblock.basic-pathfinder-2e-layoutmisc .trait_01,
-.statblock.basic-pathfinder-2e-layoutmisc .trait_02,
-.statblock.basic-pathfinder-2e-layoutmisc .trait_03,
-.statblock.basic-pathfinder-2e-layoutmisc .trait_04,
-.statblock.basic-pathfinder-2e-layoutmisc .trait_05,
-.statblock.basic-pathfinder-2e-layoutmisc .trait_06,
-.statblock.basic-pathfinder-2e-layoutmisc .trait_07 {
-    color: var(--statblock-traits-font-color) !important;
-    font-size: var(--statblock-traits-font-size);
-    font-style: var(--statblock-traits-font-style) !important;
-    font-weight: var(--statblock-traits-font-weight) !important;
-    letter-spacing: var(--statblock-traits-letter-spacing);
-    min-width: var(--statblock-traits-min-width);
-    margin: var(--statblock-traits-margins);
-    padding: var(--statblock-traits-padding);
-    text-align: var(--statblock-traits-text-align);
-    text-transform: var(--statblock-traits-text-transform);
-}
-.statblock.basic-pathfinder-2e-layoutmisc .rare_01 span.property-name,
-.statblock.basic-pathfinder-2e-layoutmisc .rare_02 span.property-name,
-.statblock.basic-pathfinder-2e-layoutmisc .rare_03 span.property-name,
-.statblock.basic-pathfinder-2e-layoutmisc .rare_04 span.property-name,
-.statblock.basic-pathfinder-2e-layoutmisc .alignment span.property-name,
-.statblock.basic-pathfinder-2e-layoutmisc .size span.property-name,
-.statblock.basic-pathfinder-2e-layoutmisc .xp span.property-name,
-.statblock.basic-pathfinder-2e-layoutmisc .kingdom_xp span.property-name,
-.statblock.basic-pathfinder-2e-layoutmisc .trait_01 span.property-name,
-.statblock.basic-pathfinder-2e-layoutmisc .trait_02 span.property-name,
-.statblock.basic-pathfinder-2e-layoutmisc .trait_03 span.property-name,
-.statblock.basic-pathfinder-2e-layoutmisc .trait_04 span.property-name,
-.statblock.basic-pathfinder-2e-layoutmisc .trait_05 span.property-name,
-.statblock.basic-pathfinder-2e-layoutmisc .trait_06 span.property-name,
-.statblock.basic-pathfinder-2e-layoutmisc .trait_07 span.property-name {
-    display: none;
-}
-.statblock.basic-pathfinder-2e-layoutmisc h3,
-.statblock.basic-pathfinder-2e-layoutmisc .markdown-rendered h3,
-.statblock.basic-pathfinder-2e-layoutmisc .HyperMD-header-3,
-.statblock.basic-pathfinder-2e-layoutmisc .inline-title[data-level="3"],
-.statblock.basic-pathfinder-2e-layoutmisc .HyperMD-list-line .cm-header-3 {
-    font-variant: var(--statblock-h3-variant);
-    letter-spacing: var(--statblock-h3-letter-spacing);
-    line-height: var(--statblock-h3-line-height);
-    font-size: var(--statblock-h3-size);
-    color: var(--statblock-h3-color);
-}
-.statblock.basic-pathfinder-2e-layoutmisc a,
-.statblock.basic-pathfinder-2e-layoutmisc a:-webkit-any-link,
-.statblock.basic-pathfinder-2e-layoutmisc a.internal-link {
-    color: var(--statblock-hyperlink-color);
-    font-weight: bolder;
-    text-decoration: var(--statblock-hyperlink-text-decoration);
-}
-.statblock.basic-pathfinder-2e-layoutmisc b,
-.statblock.basic-pathfinder-2e-layoutmisc strong,
-.statblock.basic-pathfinder-2e-layoutmisc .cm-strong {
-    font-weight: var(--statblock-property-name-font-weight);
-    color: var(--statblock-property-name-font-color);
-}
-.statblock.basic-pathfinder-2e-layoutmisc i,
-.statblock.basic-pathfinder-2e-layoutmisc em,
-.statblock.basic-pathfinder-2e-layoutmisc .cm-em {
-    font-style: italic;
-    color: var(--statblock-italic-font-color);
-    font-weight: 500;
-}
-.statblock.basic-pathfinder-2e-layoutmisc
-    .statblock-item-inline:has(.statblock-inline-item .name) {
-    display: flex;
-    flex-direction: row;
-    margin-inline: 0.25em;
-    gap: 0.25em;
-}
-.statblock.basic-pathfinder-2e-layoutmisc
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item {
-}
-.statblock.basic-pathfinder-2e-layoutmisc
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item:has(.name) {
-    flex: 1;
-}
-.statblock.basic-pathfinder-2e-layoutmisc
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .name,
-.statblock.basic-pathfinder-2e-layoutmisc
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .level {
-}
-.statblock.basic-pathfinder-2e-layoutmisc
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .name
-    p,
-.statblock.basic-pathfinder-2e-layoutmisc
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .level
-    p {
-    align-self: flex-start;
-    font-size: 1.2em;
-    font-weight: 900;
-    text-transform: uppercase;
-}
-.statblock.basic-pathfinder-2e-layoutmisc
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .name
-    span.property-name,
-.statblock.basic-pathfinder-2e-layoutmisc
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .level
-    span.property-name {
-    display: none;
-}
-.statblock.basic-pathfinder-2e-layoutmisc
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .image {
-    width: unset;
-    height: unset;
-}
-.statblock.basic-pathfinder-2e-layoutmisc
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    img {
-    width: unset;
-    height: var(--statblock-property-line-height);
-    border-radius: 0;
-    border: none;
-}
-.statblock.basic-pathfinder-2e-layoutmisc ul {
-    display: block;
-    list-style-type: var(--statblock-list-style-type);
-    margin-block-start: var(--statblock-list-margin-block-start);
-    margin-block-end: var(--statblock-list-margin-block-end);
-    margin-inline-start: var(--statblock-list-margin-inline-start);
-    margin-inline-end: var(--statblock-list-margin-inline-end);
-    padding-inline-start: var(--statblock-list-padding-inline-start);
-}
-.statblock.basic-pathfinder-2e-layoutmisc .markdown-rendered ul,
-.statblock.basic-pathfinder-2e-layoutmisc .markdown-rendered ol {
-    padding-inline-start: var(--statblock-list-indent);
-}
-.statblock.basic-pathfinder-2e-layoutmisc li {
-    color: var(--statblock-content-font);
-    display: list-item;
-    text-align: var(--statblock-list-text-align);
-}
-.statblock.basic-pathfinder-2e-layoutmisc .markdown-source-view ol > li,
-.statblock.basic-pathfinder-2e-layoutmisc .markdown-source-view ul > li,
-.statblock.basic-pathfinder-2e-layoutmisc .markdown-preview-view ol > li,
-.statblock.basic-pathfinder-2e-layoutmisc .markdown-preview-view ul > li,
-.statblock.basic-pathfinder-2e-layoutmisc .markdown-rendered ul > li,
-.statblock.basic-pathfinder-2e-layoutmisc .mod-cm6 .HyperMD-list-line.cm-line {
-    padding-top: var(--statblock-list-padding-top);
-    padding-bottom: var(--statblock-list-padding-bottom);
-}
-.statblock.basic-pathfinder-2e-layoutmisc ol > li::marker,
-.statblock.basic-pathfinder-2e-layoutmisc ul > li::marker,
-.statblock.basic-pathfinder-2e-layoutmisc .cm-s-obsidian .cm-formatting-list {
-    color: var(--list-marker-color);
-}
-.statblock.basic-pathfinder-2e-layoutmisc ::marker {
-    unicode-bidi: isolate;
-    font-variant-numeric: tabular-nums;
-    text-transform: none;
-    text-indent: 0;
-    text-align: start;
-    text-align-last: start;
-}
-.statblock.basic-pathfinder-2e-layoutquest {
-    --statblock-color-common: rgb(54, 69, 79);
-    --statblock-color-uncommon: rgb(143, 85, 66);
-    --statblock-color-rare: rgb(11, 37, 96);
-    --statblock-color-unique: rgb(77, 27, 106);
-    --statblock-color-alignment: rgb(89, 98, 143);
-    --statblock-color-size: rgb(75, 122, 92);
-    --statblock-color-trait: rgb(86, 12, 6);
-    --statblock-primary-color: rgb(51, 51, 51);
-    --statblock-rule-color: rgb(51, 51, 51);
-    --statblock-background-color: rgb(246, 244, 242);
-    --statblock-background-color-alt: rgb(229, 224, 219);
-    --statblock-bar-color: var(--statblock-rule-color);
-    --statblock-bar-border-size: 1px;
-    --statblock-bar-border-color: var(--statblock-rule-color);
-    --statblock-image-width: 75px;
-    --statblock-image-height: 75px;
-    --statblock-image-border-size: 2px;
-    --statblock-image-border-color: rgb(51, 51, 51);
-    --statblock-border-size: 1px;
-    --statblock-border-color: rgb(51, 51, 51);
-    --statblock-box-shadow-color: rgb(255, 215, 0);
-    --statblock-box-shadow-x-offset: 0;
-    --statblock-box-shadow-y-offset: 0;
-    --statblock-box-shadow-blur: 1.5em;
-    --statblock-font-color: var(--statblock-primary-color);
-    --statblock-font-weight: 400;
-    --statblock-content-font: system-ui, "Pathfinder", -apple-system,
-        BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-        "Open Sans", "Helvetica Neue", sans-serif;
-    --statblock-content-font-size: 13px;
-    --statblock-heading-font: system-ui, "Pathfinder", -apple-system,
-        BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-        "Open Sans", "Helvetica Neue", sans-serif;
-    --statblock-heading-font-color: var(--statblock-font-color);
-    --statblock-heading-font-size: 1.35em;
-    --statblock-heading-font-variant: small-caps;
-    --statblock-heading-font-weight: 700;
-    --statblock-heading-line-height: 1;
-    --statblock-property-line-height: 1.33em;
-    --statblock-property-font-color: var(--statblock-font-color);
-    --statblock-property-name-font-color: var(--statblock-font-color);
-    --statblock-property-name-font-weight: bold;
-    --statblock-section-heading-border-size: 1px;
-    --statblock-section-heading-border-color: transparent;
-    --statblock-section-heading-font-color: var(--statblock-font-color);
-    --statblock-section-heading-font-size: 1.33 empx;
-    --statblock-section-heading-font-variant: small-caps;
-    --statblock-section-heading-font-weight: 400;
-    --statblock-saves-line-height: 1.33em;
-    --statblock-spells-font-style: italic;
-    --statblock-table-header-font-weight: bold;
-    --statblock-other-font: system-ui, "Pathfinder", -apple-system,
-        BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-        "Open Sans", "Helvetica Neue", sans-serif;
-    --statblock-traits-font: system-ui, "Pathfinder", -apple-system,
-        BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-        "Open Sans", "Helvetica Neue", sans-serif;
-    --statblock-text-normal: rgb(--color-base-100);
-    --statblock-text-muted: rgb(--color-base-50);
-    --statblock-text-faint: rgba(--statblock-primary-color, 0.5);
-    --statblock-hyperlink-color: rgb(61, 102, 142);
-    --statblock-hyperlink-text-decoration: rgb(51, 51, 51) underline solid;
-    --statblock-hyperlink-text-shadow: 0.5px 0.5px 0.5px rgba(61, 102, 142);
-    --statblock-italic-font-color: rgb(77, 27, 105);
-    --statblock-h3-variant: small-caps;
-    --statblock-h3-letter-spacing: 1;
-    --statblock-h3-line-height: 1.33em;
-    --statblock-h3-size: 13px;
-    --statblock-h3-color: rgb(51, 51, 51);
-    --statblock-h3-weight: 400;
-    --statblock-h3-font-style: normal;
-    --statblock-h3-font-family: system-ui, "Pathfinder", -apple-system,
-        BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-        "Open Sans", "Helvetica Neue", sans-serif;
-    --statblock-column-width: 400px;
-    --statblock-column2-width: 1000px;
-    --statblock-traits-box-sizing: border-box;
-    --statblock-traits-font-color: rgb(255, 255, 255);
-    --statblock-traits-letter-spacing: 0.01em;
-    --statblock-traits-gap: 2px;
-    --statblock-traits-margins: 0 var(--statblock-traits-gap) 0 0;
-    --statblock-traits-min-width: 4em;
-    --statblock-traits-padding: 0.4em 1.1em 0.2em;
-    --statblock-traits-text-align: center;
-    --statblock-traits-text-transform: uppercase;
-    --statblock-traits-font-size: 12px;
-    --statblock-traits-font-style: normal;
-    --statblock-traits-font-weight: 900;
-    --statblock-list-bullet-border: none;
-    --statblock-list-bullet-radius: 50%;
-    --statblock-list-bullet-size: 0.3em;
-    --statblock-list-bullet-transform: none;
-    --statblock-list-numbered-style: decimal;
-    --statblock-list-indent: 2em;
-    --statblock-list-margin-block-start: 1em;
-    --statblock-list-margin-block-end: 1em;
-    --statblock-list-margin-inline-start: 0px;
-    --statblock-list-margin-inline-end: 0px;
-    --statblock-list-marker-color: blue;
-    --statblock-list-marker-color-collapsed: var(--text-accent);
-    --statblock-list-marker-color-hover: var(--text-muted);
-    --statblock-list-padding-inline-start: 40px;
-    --statblock-list-padding-top: 0;
-    --statblock-list-padding-bottom: 0;
-    --statblock-list-spacing: 0.075em;
-    --statblock-list-style-type: disc;
-    --statblock-list-text-align: -webkit-match-parent;
-    --statblock-upper-level-padding: 2em;
-    --statblock-upper-level-margin: 2em;
-}
-.statblock.basic-pathfinder-2e-layoutquest .bar {
-    height: 1px;
-    background: var(--statblock-bar-color);
-    border: var(--statblock-bar-border-size) solid
-        var(--statblock-bar-border-color);
-    z-index: 1;
-    width: fit-content;
-}
-.statblock.basic-pathfinder-2e-layoutquest .statblock-content {
-    font-family: var(--statblock-content-font);
-    font-size: var(--statblock-content-font-size);
-    color: var(--statblock-font-color);
-    background-color: var(--statblock-background-color);
-    padding: 0.5em;
-    border: var(--statblock-border-size) var(--statblock-border-color) solid;
-    box-shadow: var(--statblock-box-shadow-x-offset)
-        var(--statblock-box-shadow-y-offset) var(--statblock-box-shadow-blur)
-        var(--statblock-box-shadow-color);
-    margin: 0.5em 2px;
-    display: flex;
-    gap: 1rem;
-}
-.statblock.basic-pathfinder-2e-layoutquest .statblock-content .statblock-detached {
-    position: absolute;
-    top: -9999px;
-}
-.statblock.basic-pathfinder-2e-layoutquest .statblock-content .statblock-item-container {
-    margin: 0;
-    padding: 0;
-}
-.statblock.basic-pathfinder-2e-layoutquest .statblock-content .statblock-item-inline {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    align-content: flex-start;
-    align-items: baseline;
-    justify-content: flex-start;
-    margin: 0;
-    padding: 0;
-}
-.statblock.basic-pathfinder-2e-layoutquest .statblock-content > .column {
-    width: var(--statblock-column-width);
-}
-.statblock.basic-pathfinder-2e-layoutquest
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline) {
-}
-.statblock.basic-pathfinder-2e-layoutquest
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline):has(
-        .line,
-        .property
-    ) {
-    margin-block: 0.25rem;
-}
-.statblock.basic-pathfinder-2e-layoutquest
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline):has(
-        .line,
-        .property
-    ):last-child {
-    margin-bottom: 0;
-}
-.statblock.basic-pathfinder-2e-layoutquest
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline):has(.line.name) {
-    margin: 0;
-}
-.statblock.basic-pathfinder-2e-layoutquest
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline)
-    > :is(.property, .line:has(.property-name)) {
-    margin-left: 1em;
-}
-.statblock.basic-pathfinder-2e-layoutquest
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline)
-    > :is(.property, .line)
-    .property-name {
-    margin-left: -1em;
-}
-.statblock.basic-pathfinder-2e-layoutquest
-    .statblock-content
-    > .column
-    > .statblock-item-container:has(.tapered-rule) {
-    margin-block: 0.25rem;
-}
-.statblock.basic-pathfinder-2e-layoutquest
-    .statblock-content
-    > .column
-    > .statblock-item-inline:has(.name)
-    + .statblock-item-container:has(.tapered-rule) {
-    margin-top: 0;
-}
-.statblock.basic-pathfinder-2e-layoutquest
-    .statblock-content
-    > .column
-    > .statblock-item-inline:has(
-        .rare_01,
-        .rare_02,
-        .rare_03,
-        .rare_04,
-        .alignment,
-        .size,
-        .xp,
-        .kingdom_xp,
-        .trait_01,
-        .trait_02,
-        .trait_03,
-        .trait_04,
-        .trait_05,
-        .trait_06,
-        .trait_07
-    ) {
-    row-gap: var(--statblock-traits-gap);
-    margin-bottom: 0.5em;
-}
+
 @media screen and (max-width: 400px) {
-    .statblock.basic-pathfinder-2e-layoutquest .statblock-content > :global(.column) {
-        width: 75vw;
-    }
+  .statblock.pathfinder-2e-misc-layout .statblock-content > :global(.column) {
+    width: 75vw;
+  }
 }
-.statblock.basic-pathfinder-2e-layoutquest .dice-roller-result {
-    font-weight: var(--statblock-font-weight);
+.statblock.pathfinder-2e-misc-layout .spell-line .spells {
+  font-style: var(--statblock-spells-font-style);
 }
-.statblock.basic-pathfinder-2e-layoutquest .roller-result {
-    font-weight: var(--statblock-font-weight);
+.statblock.pathfinder-2e-misc-layout .statblock-table-header {
+  font-weight: var(--statblock-table-header-font-weight);
 }
-.statblock.basic-pathfinder-2e-layoutquest .image {
-    width: var(--statblock-image-width);
-    height: var(--statblock-image-height);
+.statblock.pathfinder-2e-misc-layout .table {
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+  flex-wrap: wrap;
 }
-.statblock.basic-pathfinder-2e-layoutquest .image.pointer {
-    cursor: pointer;
+.statblock.pathfinder-2e-misc-layout .table-item {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-flow: column nowrap;
 }
-.statblock.basic-pathfinder-2e-layoutquest .image img {
-    object-fit: cover;
-    width: 100%;
-    height: 100%;
-    border-radius: 100%;
-    border: var(--statblock-image-border-size) solid
-        var(--statblock-image-border-color);
-    object-position: center;
-}
-.statblock.basic-pathfinder-2e-layoutquest .line {
-    line-height: var(--statblock-property-line-height);
-    display: block;
-    color: var(--statblock-property-line-font-color);
-}
-.statblock.basic-pathfinder-2e-layoutquest .statblock-rendered-text-content {
-    color: var(--statblock-property-name-font-color);
-    font-weight: var(--statblock-property-name-font-weight);
-}
-.statblock.basic-pathfinder-2e-layoutquest .statblock-markdown,
-.statblock.basic-pathfinder-2e-layoutquest .property {
-    line-height: var(--statblock-property-line-height);
-}
-.statblock.basic-pathfinder-2e-layoutquest div.tapered-rule {
-    width: auto;
-    margin: 0;
-    height: 1px;
-    background: var(--statblock-bar-color);
-    clip-path: unset !important;
-    -webkit-clip-path: unset;
-}
-.statblock.basic-pathfinder-2e-layoutquest .flex-container {
-    align-items: center;
-    display: flex;
-    justify-content: space-between;
-}
-.statblock.basic-pathfinder-2e-layoutquest .heading {
-    align-items: center;
-    color: var(--statblock-heading-font-color);
-    display: flex;
-    font-family: var(--statblock-heading-font);
-    font-variant: var(--statblock-heading-font-variant);
-    font-weight: var(--statblock-heading-font-weight);
-    justify-content: space-between;
-    line-height: var(--statblock-heading-line-height);
-    letter-spacing: 1px;
-    margin: 0;
-}
-.statblock.basic-pathfinder-2e-layoutquest h1.section-header {
-    border: none;
-    color: var(--statblock-section-heading-font-color);
-    font-size: var(--statblock-section-heading-font-size);
-    font-variant: var(--statblock-section-heading-font-variant);
-    font-weight: var(--statblock-section-heading-font-weight);
-    letter-spacing: 1px;
-    margin: 0;
-    margin-bottom: 0.3em;
-    break-inside: avoid-column;
-    break-after: avoid-column;
-}
-.statblock.basic-pathfinder-2e-layoutquest h2.section-header {
-    border: none;
-    color: var(--statblock-section-heading-font-color);
-    font-size: var(--statblock-section-heading-font-size);
-    font-variant: var(--statblock-section-heading-font-variant);
-    font-weight: var(--statblock-section-heading-font-weight);
-    letter-spacing: 1px;
-    margin: 0;
-    margin-bottom: 0.3em;
-    break-inside: avoid-column;
-    break-after: avoid-column;
-}
-.statblock.basic-pathfinder-2e-layoutquest h3.section-header {
-    border: none;
-    color: var(--statblock-section-heading-font-color);
-    font-size: var(--statblock-section-heading-font-size);
-    font-variant: var(--statblock-section-heading-font-variant);
-    font-weight: var(--statblock-section-heading-font-weight);
-    letter-spacing: 1px;
-    margin: 0;
-    margin-bottom: 0;
-    break-inside: avoid-column;
-    break-after: avoid-column;
-    display: none;
-}
-.statblock.basic-pathfinder-2e-layoutquest .spell-line .spells {
-    font-style: var(--statblock-spells-font-style);
-}
-.statblock.basic-pathfinder-2e-layoutquest .statblock-table-header {
-    font-weight: var(--statblock-table-header-font-weight);
-}
-.statblock.basic-pathfinder-2e-layoutquest .table {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: center;
-    flex-wrap: wrap;
-}
-.statblock.basic-pathfinder-2e-layoutquest .table-item {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    flex-flow: column nowrap;
-}
-.statblock.basic-pathfinder-2e-layoutquest .traits {
-    margin: 0 0.25em 0 0;
-    display: inline;
-    font-weight: var(--statblock-traits-font-weight) !important;
-    font-style: var(--statblock-traits-font-style) !important;
-}
-.statblock.basic-pathfinder-2e-layoutquest .rare_01 {
-    background-color: var(--statblock-color-common) !important;
-}
-.statblock.basic-pathfinder-2e-layoutquest .rare_02 {
-    background-color: var(--statblock-color-uncommon) !important;
-}
-.statblock.basic-pathfinder-2e-layoutquest .rare_03 {
-    background-color: var(--statblock-color-rare) !important;
-}
-.statblock.basic-pathfinder-2e-layoutquest .rare_04 {
-    background-color: var(--statblock-color-unique) !important;
-}
-.statblock.basic-pathfinder-2e-layoutquest .alignment {
-    background-color: var(--statblock-color-alignment) !important;
-}
-.statblock.basic-pathfinder-2e-layoutquest .size {
-    background-color: var(--statblock-color-size) !important;
-}
-.statblock.basic-pathfinder-2e-layoutquest .xp,
-.statblock.basic-pathfinder-2e-layoutquest .kingdom_xp,
-.statblock.basic-pathfinder-2e-layoutquest .trait_01,
-.statblock.basic-pathfinder-2e-layoutquest .trait_02,
-.statblock.basic-pathfinder-2e-layoutquest .trait_03,
-.statblock.basic-pathfinder-2e-layoutquest .trait_04,
-.statblock.basic-pathfinder-2e-layoutquest .trait_05,
-.statblock.basic-pathfinder-2e-layoutquest .trait_06,
-.statblock.basic-pathfinder-2e-layoutquest .trait_07 {
-    background-color: var(--statblock-color-trait) !important;
-}
-.statblock.basic-pathfinder-2e-layoutquest .rare_01,
-.statblock.basic-pathfinder-2e-layoutquest .rare_02,
-.statblock.basic-pathfinder-2e-layoutquest .rare_03,
-.statblock.basic-pathfinder-2e-layoutquest .rare_04,
-.statblock.basic-pathfinder-2e-layoutquest .alignment,
-.statblock.basic-pathfinder-2e-layoutquest .size,
-.statblock.basic-pathfinder-2e-layoutquest .xp,
-.statblock.basic-pathfinder-2e-layoutquest .kingdom_xp,
-.statblock.basic-pathfinder-2e-layoutquest .trait_01,
-.statblock.basic-pathfinder-2e-layoutquest .trait_02,
-.statblock.basic-pathfinder-2e-layoutquest .trait_03,
-.statblock.basic-pathfinder-2e-layoutquest .trait_04,
-.statblock.basic-pathfinder-2e-layoutquest .trait_05,
-.statblock.basic-pathfinder-2e-layoutquest .trait_06,
-.statblock.basic-pathfinder-2e-layoutquest .trait_07 {
-    color: var(--statblock-traits-font-color) !important;
-    font-size: var(--statblock-traits-font-size);
-    font-style: var(--statblock-traits-font-style) !important;
-    font-weight: var(--statblock-traits-font-weight) !important;
-    letter-spacing: var(--statblock-traits-letter-spacing);
-    min-width: var(--statblock-traits-min-width);
-    margin: var(--statblock-traits-margins);
-    padding: var(--statblock-traits-padding);
-    text-align: var(--statblock-traits-text-align);
-    text-transform: var(--statblock-traits-text-transform);
-}
-.statblock.basic-pathfinder-2e-layoutquest .rare_01 span.property-name,
-.statblock.basic-pathfinder-2e-layoutquest .rare_02 span.property-name,
-.statblock.basic-pathfinder-2e-layoutquest .rare_03 span.property-name,
-.statblock.basic-pathfinder-2e-layoutquest .rare_04 span.property-name,
-.statblock.basic-pathfinder-2e-layoutquest .alignment span.property-name,
-.statblock.basic-pathfinder-2e-layoutquest .size span.property-name,
-.statblock.basic-pathfinder-2e-layoutquest .xp span.property-name,
-.statblock.basic-pathfinder-2e-layoutquest .kingdom_xp span.property-name,
-.statblock.basic-pathfinder-2e-layoutquest .trait_01 span.property-name,
-.statblock.basic-pathfinder-2e-layoutquest .trait_02 span.property-name,
-.statblock.basic-pathfinder-2e-layoutquest .trait_03 span.property-name,
-.statblock.basic-pathfinder-2e-layoutquest .trait_04 span.property-name,
-.statblock.basic-pathfinder-2e-layoutquest .trait_05 span.property-name,
-.statblock.basic-pathfinder-2e-layoutquest .trait_06 span.property-name,
-.statblock.basic-pathfinder-2e-layoutquest .trait_07 span.property-name {
-    display: none;
-}
-.statblock.basic-pathfinder-2e-layoutquest h3,
-.statblock.basic-pathfinder-2e-layoutquest .markdown-rendered h3,
-.statblock.basic-pathfinder-2e-layoutquest .HyperMD-header-3,
-.statblock.basic-pathfinder-2e-layoutquest .inline-title[data-level="3"],
-.statblock.basic-pathfinder-2e-layoutquest .HyperMD-list-line .cm-header-3 {
-    font-variant: var(--statblock-h3-variant);
-    letter-spacing: var(--statblock-h3-letter-spacing);
-    line-height: var(--statblock-h3-line-height);
-    font-size: var(--statblock-h3-size);
-    color: var(--statblock-h3-color);
-}
-.statblock.basic-pathfinder-2e-layoutquest a,
-.statblock.basic-pathfinder-2e-layoutquest a:-webkit-any-link,
-.statblock.basic-pathfinder-2e-layoutquest a.internal-link {
-    color: var(--statblock-hyperlink-color);
-    font-weight: bolder;
-    text-decoration: var(--statblock-hyperlink-text-decoration);
-}
-.statblock.basic-pathfinder-2e-layoutquest b,
-.statblock.basic-pathfinder-2e-layoutquest strong,
-.statblock.basic-pathfinder-2e-layoutquest .cm-strong {
-    font-weight: var(--statblock-property-name-font-weight);
-    color: var(--statblock-property-name-font-color);
-}
-.statblock.basic-pathfinder-2e-layoutquest i,
-.statblock.basic-pathfinder-2e-layoutquest em,
-.statblock.basic-pathfinder-2e-layoutquest .cm-em {
-    font-style: italic;
-    color: var(--statblock-italic-font-color);
-    font-weight: 500;
-}
-.statblock.basic-pathfinder-2e-layoutquest
-    .statblock-item-inline:has(.statblock-inline-item .name) {
-    display: flex;
-    flex-direction: row;
-    margin-inline: 0.25em;
-    gap: 0.25em;
-}
-.statblock.basic-pathfinder-2e-layoutquest
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item {
-}
-.statblock.basic-pathfinder-2e-layoutquest
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item:has(.name) {
-    flex: 1;
-}
-.statblock.basic-pathfinder-2e-layoutquest
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .name,
-.statblock.basic-pathfinder-2e-layoutquest
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .level {
-}
-.statblock.basic-pathfinder-2e-layoutquest
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .name
-    p,
-.statblock.basic-pathfinder-2e-layoutquest
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .level
-    p {
-    align-self: flex-start;
-    font-size: 1.2em;
-    font-weight: 900;
-    text-transform: uppercase;
-}
-.statblock.basic-pathfinder-2e-layoutquest
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .name
-    span.property-name,
-.statblock.basic-pathfinder-2e-layoutquest
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .level
-    span.property-name {
-    display: none;
-}
-.statblock.basic-pathfinder-2e-layoutquest
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .image {
-    width: unset;
-    height: unset;
-}
-.statblock.basic-pathfinder-2e-layoutquest
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    img {
-    width: unset;
-    height: var(--statblock-property-line-height);
-    border-radius: 0;
-    border: none;
-}
-.statblock.basic-pathfinder-2e-layoutquest ul {
-    display: block;
-    list-style-type: var(--statblock-list-style-type);
-    margin-block-start: var(--statblock-list-margin-block-start);
-    margin-block-end: var(--statblock-list-margin-block-end);
-    margin-inline-start: var(--statblock-list-margin-inline-start);
-    margin-inline-end: var(--statblock-list-margin-inline-end);
-    padding-inline-start: var(--statblock-list-padding-inline-start);
-}
-.statblock.basic-pathfinder-2e-layoutquest .markdown-rendered ul,
-.statblock.basic-pathfinder-2e-layoutquest .markdown-rendered ol {
-    padding-inline-start: var(--statblock-list-indent);
-}
-.statblock.basic-pathfinder-2e-layoutquest li {
-    color: var(--statblock-content-font);
-    display: list-item;
-    text-align: var(--statblock-list-text-align);
-}
-.statblock.basic-pathfinder-2e-layoutquest .markdown-source-view ol > li,
-.statblock.basic-pathfinder-2e-layoutquest .markdown-source-view ul > li,
-.statblock.basic-pathfinder-2e-layoutquest .markdown-preview-view ol > li,
-.statblock.basic-pathfinder-2e-layoutquest .markdown-preview-view ul > li,
-.statblock.basic-pathfinder-2e-layoutquest .markdown-rendered ul > li,
-.statblock.basic-pathfinder-2e-layoutquest .mod-cm6 .HyperMD-list-line.cm-line {
-    padding-top: var(--statblock-list-padding-top);
-    padding-bottom: var(--statblock-list-padding-bottom);
-}
-.statblock.basic-pathfinder-2e-layoutquest ol > li::marker,
-.statblock.basic-pathfinder-2e-layoutquest ul > li::marker,
-.statblock.basic-pathfinder-2e-layoutquest .cm-s-obsidian .cm-formatting-list {
-    color: var(--list-marker-color);
-}
-.statblock.basic-pathfinder-2e-layoutquest ::marker {
-    unicode-bidi: isolate;
-    font-variant-numeric: tabular-nums;
-    text-transform: none;
-    text-indent: 0;
-    text-align: start;
-    text-align-last: start;
-}
-.statblock.basic-pathfinder-2e-layoutset {
-    --statblock-color-common: rgb(54, 69, 79);
-    --statblock-color-uncommon: rgb(143, 85, 66);
-    --statblock-color-rare: rgb(11, 37, 96);
-    --statblock-color-unique: rgb(77, 27, 106);
-    --statblock-color-alignment: rgb(89, 98, 143);
-    --statblock-color-size: rgb(75, 122, 92);
-    --statblock-color-trait: rgb(86, 12, 6);
-    --statblock-primary-color: rgb(51, 51, 51);
-    --statblock-rule-color: rgb(51, 51, 51);
-    --statblock-background-color: rgb(246, 244, 242);
-    --statblock-background-color-alt: rgb(229, 224, 219);
-    --statblock-bar-color: var(--statblock-rule-color);
-    --statblock-bar-border-size: 1px;
-    --statblock-bar-border-color: var(--statblock-rule-color);
-    --statblock-image-width: 75px;
-    --statblock-image-height: 75px;
-    --statblock-image-border-size: 2px;
-    --statblock-image-border-color: rgb(51, 51, 51);
-    --statblock-border-size: 1px;
-    --statblock-border-color: rgb(51, 51, 51);
-    --statblock-box-shadow-color: rgb(255, 215, 0);
-    --statblock-box-shadow-x-offset: 0;
-    --statblock-box-shadow-y-offset: 0;
-    --statblock-box-shadow-blur: 1.5em;
-    --statblock-font-color: var(--statblock-primary-color);
-    --statblock-font-weight: 400;
-    --statblock-content-font: system-ui, "Pathfinder", -apple-system,
-        BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-        "Open Sans", "Helvetica Neue", sans-serif;
-    --statblock-content-font-size: 13px;
-    --statblock-heading-font: system-ui, "Pathfinder", -apple-system,
-        BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-        "Open Sans", "Helvetica Neue", sans-serif;
-    --statblock-heading-font-color: var(--statblock-font-color);
-    --statblock-heading-font-size: 1.35em;
-    --statblock-heading-font-variant: small-caps;
-    --statblock-heading-font-weight: 700;
-    --statblock-heading-line-height: 1;
-    --statblock-property-line-height: 1.33em;
-    --statblock-property-font-color: var(--statblock-font-color);
-    --statblock-property-name-font-color: var(--statblock-font-color);
-    --statblock-property-name-font-weight: bold;
-    --statblock-section-heading-border-size: 1px;
-    --statblock-section-heading-border-color: transparent;
-    --statblock-section-heading-font-color: var(--statblock-font-color);
-    --statblock-section-heading-font-size: 1.33 empx;
-    --statblock-section-heading-font-variant: small-caps;
-    --statblock-section-heading-font-weight: 400;
-    --statblock-saves-line-height: 1.33em;
-    --statblock-spells-font-style: italic;
-    --statblock-table-header-font-weight: bold;
-    --statblock-other-font: system-ui, "Pathfinder", -apple-system,
-        BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-        "Open Sans", "Helvetica Neue", sans-serif;
-    --statblock-traits-font: system-ui, "Pathfinder", -apple-system,
-        BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-        "Open Sans", "Helvetica Neue", sans-serif;
-    --statblock-text-normal: rgb(--color-base-100);
-    --statblock-text-muted: rgb(--color-base-50);
-    --statblock-text-faint: rgba(--statblock-primary-color, 0.5);
-    --statblock-hyperlink-color: rgb(61, 102, 142);
-    --statblock-hyperlink-text-decoration: rgb(51, 51, 51) underline solid;
-    --statblock-hyperlink-text-shadow: 0.5px 0.5px 0.5px rgba(61, 102, 142);
-    --statblock-italic-font-color: rgb(77, 27, 105);
-    --statblock-h3-variant: small-caps;
-    --statblock-h3-letter-spacing: 1;
-    --statblock-h3-line-height: 1.33em;
-    --statblock-h3-size: 13px;
-    --statblock-h3-color: rgb(51, 51, 51);
-    --statblock-h3-weight: 400;
-    --statblock-h3-font-style: normal;
-    --statblock-h3-font-family: system-ui, "Pathfinder", -apple-system,
-        BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-        "Open Sans", "Helvetica Neue", sans-serif;
-    --statblock-column-width: 400px;
-    --statblock-column2-width: 1000px;
-    --statblock-traits-box-sizing: border-box;
-    --statblock-traits-font-color: rgb(255, 255, 255);
-    --statblock-traits-letter-spacing: 0.01em;
-    --statblock-traits-gap: 2px;
-    --statblock-traits-margins: 0 var(--statblock-traits-gap) 0 0;
-    --statblock-traits-min-width: 4em;
-    --statblock-traits-padding: 0.4em 1.1em 0.2em;
-    --statblock-traits-text-align: center;
-    --statblock-traits-text-transform: uppercase;
-    --statblock-traits-font-size: 12px;
-    --statblock-traits-font-style: normal;
-    --statblock-traits-font-weight: 900;
-    --statblock-list-bullet-border: none;
-    --statblock-list-bullet-radius: 50%;
-    --statblock-list-bullet-size: 0.3em;
-    --statblock-list-bullet-transform: none;
-    --statblock-list-numbered-style: decimal;
-    --statblock-list-indent: 2em;
-    --statblock-list-margin-block-start: 1em;
-    --statblock-list-margin-block-end: 1em;
-    --statblock-list-margin-inline-start: 0px;
-    --statblock-list-margin-inline-end: 0px;
-    --statblock-list-marker-color: blue;
-    --statblock-list-marker-color-collapsed: var(--text-accent);
-    --statblock-list-marker-color-hover: var(--text-muted);
-    --statblock-list-padding-inline-start: 40px;
-    --statblock-list-padding-top: 0;
-    --statblock-list-padding-bottom: 0;
-    --statblock-list-spacing: 0.075em;
-    --statblock-list-style-type: disc;
-    --statblock-list-text-align: -webkit-match-parent;
-    --statblock-upper-level-padding: 2em;
-    --statblock-upper-level-margin: 2em;
-}
-.statblock.basic-pathfinder-2e-layoutset .bar {
-    height: 1px;
-    background: var(--statblock-bar-color);
-    border: var(--statblock-bar-border-size) solid
-        var(--statblock-bar-border-color);
-    z-index: 1;
-    width: fit-content;
-}
-.statblock.basic-pathfinder-2e-layoutset .statblock-content {
-    font-family: var(--statblock-content-font);
-    font-size: var(--statblock-content-font-size);
-    color: var(--statblock-font-color);
-    background-color: var(--statblock-background-color);
-    padding: 0.5em;
-    border: var(--statblock-border-size) var(--statblock-border-color) solid;
-    box-shadow: var(--statblock-box-shadow-x-offset)
-        var(--statblock-box-shadow-y-offset) var(--statblock-box-shadow-blur)
-        var(--statblock-box-shadow-color);
-    margin: 0.5em 2px;
-    display: flex;
-    gap: 1rem;
-}
-.statblock.basic-pathfinder-2e-layoutset .statblock-content .statblock-detached {
-    position: absolute;
-    top: -9999px;
-}
-.statblock.basic-pathfinder-2e-layoutset .statblock-content .statblock-item-container {
-    margin: 0;
-    padding: 0;
-}
-.statblock.basic-pathfinder-2e-layoutset .statblock-content .statblock-item-inline {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    align-content: flex-start;
-    align-items: baseline;
-    justify-content: flex-start;
-    margin: 0;
-    padding: 0;
-}
-.statblock.basic-pathfinder-2e-layoutset .statblock-content > .column {
-    width: var(--statblock-column-width);
-}
-.statblock.basic-pathfinder-2e-layoutset
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline) {
-}
-.statblock.basic-pathfinder-2e-layoutset
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline):has(
-        .line,
-        .property
-    ) {
-    margin-block: 0.25rem;
-}
-.statblock.basic-pathfinder-2e-layoutset
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline):has(
-        .line,
-        .property
-    ):last-child {
-    margin-bottom: 0;
-}
-.statblock.basic-pathfinder-2e-layoutset
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline):has(.line.name) {
-    margin: 0;
-}
-.statblock.basic-pathfinder-2e-layoutset
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline)
-    > :is(.property, .line:has(.property-name)) {
-    margin-left: 1em;
-}
-.statblock.basic-pathfinder-2e-layoutset
-    .statblock-content
-    > .column
-    > :is(.statblock-item-container, .statblock-item-inline)
-    > :is(.property, .line)
-    .property-name {
-    margin-left: -1em;
-}
-.statblock.basic-pathfinder-2e-layoutset
-    .statblock-content
-    > .column
-    > .statblock-item-container:has(.tapered-rule) {
-    margin-block: 0.25rem;
-}
-.statblock.basic-pathfinder-2e-layoutset
-    .statblock-content
-    > .column
-    > .statblock-item-inline:has(.name)
-    + .statblock-item-container:has(.tapered-rule) {
-    margin-top: 0;
-}
-.statblock.basic-pathfinder-2e-layoutset
-    .statblock-content
-    > .column
-    > .statblock-item-inline:has(
-        .rare_01,
-        .rare_02,
-        .rare_03,
-        .rare_04,
-        .alignment,
-        .size,
-        .xp,
-        .kingdom_xp,
-        .trait_01,
-        .trait_02,
-        .trait_03,
-        .trait_04,
-        .trait_05,
-        .trait_06,
-        .trait_07
-    ) {
-    row-gap: var(--statblock-traits-gap);
-    margin-bottom: 0.5em;
-}
+
 @media screen and (max-width: 400px) {
-    .statblock.basic-pathfinder-2e-layoutset .statblock-content > :global(.column) {
-        width: 75vw;
-    }
+  .statblock.pathfinder-2e-quest-layout .statblock-content > :global(.column) {
+    width: 75vw;
+  }
 }
-.statblock.basic-pathfinder-2e-layoutset .dice-roller-result {
-    font-weight: var(--statblock-font-weight);
+.statblock.pathfinder-2e-quest-layout .spell-line .spells {
+  font-style: var(--statblock-spells-font-style);
 }
-.statblock.basic-pathfinder-2e-layoutset .roller-result {
-    font-weight: var(--statblock-font-weight);
+.statblock.pathfinder-2e-quest-layout .statblock-table-header {
+  font-weight: var(--statblock-table-header-font-weight);
 }
-.statblock.basic-pathfinder-2e-layoutset .image {
-    width: var(--statblock-image-width);
-    height: var(--statblock-image-height);
+.statblock.pathfinder-2e-quest-layout .table {
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+  flex-wrap: wrap;
 }
-.statblock.basic-pathfinder-2e-layoutset .image.pointer {
-    cursor: pointer;
+.statblock.pathfinder-2e-quest-layout .table-item {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-flow: column nowrap;
 }
-.statblock.basic-pathfinder-2e-layoutset .image img {
-    object-fit: cover;
-    width: 100%;
-    height: 100%;
-    border-radius: 100%;
-    border: var(--statblock-image-border-size) solid
-        var(--statblock-image-border-color);
-    object-position: center;
+
+@media screen and (max-width: 400px) {
+  .statblock.pathfinder-2e-settlement-layout .statblock-content > :global(.column) {
+    width: 75vw;
+  }
 }
-.statblock.basic-pathfinder-2e-layoutset .line {
-    line-height: var(--statblock-property-line-height);
-    display: block;
-    color: var(--statblock-property-line-font-color);
+.statblock.pathfinder-2e-settlement-layout .spell-line .spells {
+  font-style: var(--statblock-spells-font-style);
 }
-.statblock.basic-pathfinder-2e-layoutset .statblock-rendered-text-content {
-    color: var(--statblock-property-name-font-color);
-    font-weight: var(--statblock-property-name-font-weight);
+.statblock.pathfinder-2e-settlement-layout .statblock-table-header {
+  font-weight: var(--statblock-table-header-font-weight);
 }
-.statblock.basic-pathfinder-2e-layoutset .statblock-markdown,
-.statblock.basic-pathfinder-2e-layoutset .property {
-    line-height: var(--statblock-property-line-height);
+.statblock.pathfinder-2e-settlement-layout .table {
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+  flex-wrap: wrap;
 }
-.statblock.basic-pathfinder-2e-layoutset div.tapered-rule {
-    width: auto;
-    margin: 0;
-    height: 1px;
-    background: var(--statblock-bar-color);
-    clip-path: unset !important;
-    -webkit-clip-path: unset;
+.statblock.pathfinder-2e-settlement-layout .table-item {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-flow: column nowrap;
 }
-.statblock.basic-pathfinder-2e-layoutset .flex-container {
-    align-items: center;
-    display: flex;
-    justify-content: space-between;
+
+body {
+  --popover-width: none;
+  --popover-max-height: none;
+  --pop-over-height: none;
 }
-.statblock.basic-pathfinder-2e-layoutset .heading {
-    align-items: center;
-    color: var(--statblock-heading-font-color);
-    display: flex;
-    font-family: var(--statblock-heading-font);
-    font-variant: var(--statblock-heading-font-variant);
-    font-weight: var(--statblock-heading-font-weight);
-    justify-content: space-between;
-    line-height: var(--statblock-heading-line-height);
-    letter-spacing: 1px;
-    margin: 0;
+
+body .popover.hover-popover > .markdown-embed > .markdown-embed-content > .markdown-preview-view {
+  padding: 10px;
 }
-.statblock.basic-pathfinder-2e-layoutset h1.section-header {
-    border: none;
-    color: var(--statblock-section-heading-font-color);
-    font-size: var(--statblock-section-heading-font-size);
-    font-variant: var(--statblock-section-heading-font-variant);
-    font-weight: var(--statblock-section-heading-font-weight);
-    letter-spacing: 1px;
-    margin: 0;
-    margin-bottom: 0.3em;
-    break-inside: avoid-column;
-    break-after: avoid-column;
+body .popover.hover-popover > .markdown-embed > .markdown-embed-content > .markdown-preview-view .admonition.statblock-pf2e,
+body .popover.hover-popover > .markdown-embed > .markdown-embed-content > .markdown-preview-view .statblock.basic-pathfinder-2e-layout {
+  border-radius: 0;
+  max-height: 50vh;
+  width: 75vw;
 }
-.statblock.basic-pathfinder-2e-layoutset h2.section-header {
-    border: none;
-    color: var(--statblock-section-heading-font-color);
-    font-size: var(--statblock-section-heading-font-size);
-    font-variant: var(--statblock-section-heading-font-variant);
-    font-weight: var(--statblock-section-heading-font-weight);
-    letter-spacing: 1px;
-    margin: 0;
-    margin-bottom: 0.3em;
-    break-inside: avoid-column;
-    break-after: avoid-column;
+body .popover.hover-popover > .markdown-embed > .markdown-embed-content > .markdown-preview-view .admonition.statblock-pf2e,
+body .popover.hover-popover > .markdown-embed > .markdown-embed-content > .markdown-preview-view .statblock.pathfinder-2e-action-layout {
+  border-radius: 0;
+  max-height: 50vh;
+  width: 75vw;
 }
-.statblock.basic-pathfinder-2e-layoutset h3.section-header {
-    border: none;
-    color: var(--statblock-section-heading-font-color);
-    font-size: var(--statblock-section-heading-font-size);
-    font-variant: var(--statblock-section-heading-font-variant);
-    font-weight: var(--statblock-section-heading-font-weight);
-    letter-spacing: 1px;
-    margin: 0;
-    margin-bottom: 0;
-    break-inside: avoid-column;
-    break-after: avoid-column;
-    display: none;
+body .popover.hover-popover > .markdown-embed > .markdown-embed-content > .markdown-preview-view .admonition.statblock-pf2e,
+body .popover.hover-popover > .markdown-embed > .markdown-embed-content > .markdown-preview-view .statblock.pathfinder-2e-hazard-layout {
+  border-radius: 0;
+  max-height: 50vh;
+  width: 75vw;
 }
-.statblock.basic-pathfinder-2e-layoutset .spell-line .spells {
-    font-style: var(--statblock-spells-font-style);
+body .popover.hover-popover > .markdown-embed > .markdown-embed-content > .markdown-preview-view .admonition.statblock-pf2e,
+body .popover.hover-popover > .markdown-embed > .markdown-embed-content > .markdown-preview-view .statblock.pathfinder-2e-influence-layout {
+  border-radius: 0;
+  max-height: 50vh;
+  width: 75vw;
 }
-.statblock.basic-pathfinder-2e-layoutset .statblock-table-header {
-    font-weight: var(--statblock-table-header-font-weight);
+body .popover.hover-popover > .markdown-embed > .markdown-embed-content > .markdown-preview-view .admonition.statblock-pf2e,
+body .popover.hover-popover > .markdown-embed > .markdown-embed-content > .markdown-preview-view .statblock.pathfinder-2e-misc-layout {
+  border-radius: 0;
+  max-height: 50vh;
+  width: 75vw;
 }
-.statblock.basic-pathfinder-2e-layoutset .table {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: center;
-    flex-wrap: wrap;
+body .popover.hover-popover > .markdown-embed > .markdown-embed-content > .markdown-preview-view .admonition.statblock-pf2e,
+body .popover.hover-popover > .markdown-embed > .markdown-embed-content > .markdown-preview-view .statblock.pathfinder-2e-quest-layout {
+  border-radius: 0;
+  max-height: 50vh;
+  width: 75vw;
 }
-.statblock.basic-pathfinder-2e-layoutset .table-item {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    flex-flow: column nowrap;
+body .popover.hover-popover > .markdown-embed > .markdown-embed-content > .markdown-preview-view .admonition.statblock-pf2e,
+body .popover.hover-popover > .markdown-embed > .markdown-embed-content > .markdown-preview-view .statblock.pathfinder-2e-settlement-layout {
+  border-radius: 0;
+  max-height: 50vh;
+  width: 75vw;
 }
-.statblock.basic-pathfinder-2e-layoutset .traits {
-    margin: 0 0.25em 0 0;
-    display: inline;
-    font-weight: var(--statblock-traits-font-weight) !important;
-    font-style: var(--statblock-traits-font-style) !important;
+body .popover.hover-popover:has(.admonition.statblock-pf2e, .statblock) {
+  border: rgb(226, 105, 134) 0 dashed;
+  border-radius: 0;
+  max-height: 50vh;
+  width: 75vw;
 }
-.statblock.basic-pathfinder-2e-layoutset .rare_01 {
-    background-color: var(--statblock-color-common) !important;
+body .popover.hover-popover:has(.statblock) {
+  top: 1em;
 }
-.statblock.basic-pathfinder-2e-layoutset .rare_02 {
-    background-color: var(--statblock-color-uncommon) !important;
-}
-.statblock.basic-pathfinder-2e-layoutset .rare_03 {
-    background-color: var(--statblock-color-rare) !important;
-}
-.statblock.basic-pathfinder-2e-layoutset .rare_04 {
-    background-color: var(--statblock-color-unique) !important;
-}
-.statblock.basic-pathfinder-2e-layoutset .alignment {
-    background-color: var(--statblock-color-alignment) !important;
-}
-.statblock.basic-pathfinder-2e-layoutset .size {
-    background-color: var(--statblock-color-size) !important;
-}
-.statblock.basic-pathfinder-2e-layoutset .xp,
-.statblock.basic-pathfinder-2e-layoutset .kingdom_xp,
-.statblock.basic-pathfinder-2e-layoutset .trait_01,
-.statblock.basic-pathfinder-2e-layoutset .trait_02,
-.statblock.basic-pathfinder-2e-layoutset .trait_03,
-.statblock.basic-pathfinder-2e-layoutset .trait_04,
-.statblock.basic-pathfinder-2e-layoutset .trait_05,
-.statblock.basic-pathfinder-2e-layoutset .trait_06,
-.statblock.basic-pathfinder-2e-layoutset .trait_07 {
-    background-color: var(--statblock-color-trait) !important;
-}
-.statblock.basic-pathfinder-2e-layoutset .rare_01,
-.statblock.basic-pathfinder-2e-layoutset .rare_02,
-.statblock.basic-pathfinder-2e-layoutset .rare_03,
-.statblock.basic-pathfinder-2e-layoutset .rare_04,
-.statblock.basic-pathfinder-2e-layoutset .alignment,
-.statblock.basic-pathfinder-2e-layoutset .size,
-.statblock.basic-pathfinder-2e-layoutset .xp,
-.statblock.basic-pathfinder-2e-layoutset .kingdom_xp,
-.statblock.basic-pathfinder-2e-layoutset .trait_01,
-.statblock.basic-pathfinder-2e-layoutset .trait_02,
-.statblock.basic-pathfinder-2e-layoutset .trait_03,
-.statblock.basic-pathfinder-2e-layoutset .trait_04,
-.statblock.basic-pathfinder-2e-layoutset .trait_05,
-.statblock.basic-pathfinder-2e-layoutset .trait_06,
-.statblock.basic-pathfinder-2e-layoutset .trait_07 {
-    color: var(--statblock-traits-font-color) !important;
-    font-size: var(--statblock-traits-font-size);
-    font-style: var(--statblock-traits-font-style) !important;
-    font-weight: var(--statblock-traits-font-weight) !important;
-    letter-spacing: var(--statblock-traits-letter-spacing);
-    min-width: var(--statblock-traits-min-width);
-    margin: var(--statblock-traits-margins);
-    padding: var(--statblock-traits-padding);
-    text-align: var(--statblock-traits-text-align);
-    text-transform: var(--statblock-traits-text-transform);
-}
-.statblock.basic-pathfinder-2e-layoutset .rare_01 span.property-name,
-.statblock.basic-pathfinder-2e-layoutset .rare_02 span.property-name,
-.statblock.basic-pathfinder-2e-layoutset .rare_03 span.property-name,
-.statblock.basic-pathfinder-2e-layoutset .rare_04 span.property-name,
-.statblock.basic-pathfinder-2e-layoutset .alignment span.property-name,
-.statblock.basic-pathfinder-2e-layoutset .size span.property-name,
-.statblock.basic-pathfinder-2e-layoutset .xp span.property-name,
-.statblock.basic-pathfinder-2e-layoutset .kingdom_xp span.property-name,
-.statblock.basic-pathfinder-2e-layoutset .trait_01 span.property-name,
-.statblock.basic-pathfinder-2e-layoutset .trait_02 span.property-name,
-.statblock.basic-pathfinder-2e-layoutset .trait_03 span.property-name,
-.statblock.basic-pathfinder-2e-layoutset .trait_04 span.property-name,
-.statblock.basic-pathfinder-2e-layoutset .trait_05 span.property-name,
-.statblock.basic-pathfinder-2e-layoutset .trait_06 span.property-name,
-.statblock.basic-pathfinder-2e-layoutset .trait_07 span.property-name {
-    display: none;
-}
-.statblock.basic-pathfinder-2e-layoutset h3,
-.statblock.basic-pathfinder-2e-layoutset .markdown-rendered h3,
-.statblock.basic-pathfinder-2e-layoutset .HyperMD-header-3,
-.statblock.basic-pathfinder-2e-layoutset .inline-title[data-level="3"],
-.statblock.basic-pathfinder-2e-layoutset .HyperMD-list-line .cm-header-3 {
-    font-variant: var(--statblock-h3-variant);
-    letter-spacing: var(--statblock-h3-letter-spacing);
-    line-height: var(--statblock-h3-line-height);
-    font-size: var(--statblock-h3-size);
-    color: var(--statblock-h3-color);
-}
-.statblock.basic-pathfinder-2e-layoutset a,
-.statblock.basic-pathfinder-2e-layoutset a:-webkit-any-link,
-.statblock.basic-pathfinder-2e-layoutset a.internal-link {
-    color: var(--statblock-hyperlink-color);
-    font-weight: bolder;
-    text-decoration: var(--statblock-hyperlink-text-decoration);
-}
-.statblock.basic-pathfinder-2e-layoutset b,
-.statblock.basic-pathfinder-2e-layoutset strong,
-.statblock.basic-pathfinder-2e-layoutset .cm-strong {
-    font-weight: var(--statblock-property-name-font-weight);
-    color: var(--statblock-property-name-font-color);
-}
-.statblock.basic-pathfinder-2e-layoutset i,
-.statblock.basic-pathfinder-2e-layoutset em,
-.statblock.basic-pathfinder-2e-layoutset .cm-em {
-    font-style: italic;
-    color: var(--statblock-italic-font-color);
-    font-weight: 500;
-}
-.statblock.basic-pathfinder-2e-layoutset
-    .statblock-item-inline:has(.statblock-inline-item .name) {
-    display: flex;
-    flex-direction: row;
-    margin-inline: 0.25em;
-    gap: 0.25em;
-}
-.statblock.basic-pathfinder-2e-layoutset
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item {
-}
-.statblock.basic-pathfinder-2e-layoutset
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item:has(.name) {
-    flex: 1;
-}
-.statblock.basic-pathfinder-2e-layoutset
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .name,
-.statblock.basic-pathfinder-2e-layoutset
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .level {
-}
-.statblock.basic-pathfinder-2e-layoutset
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .name
-    p,
-.statblock.basic-pathfinder-2e-layoutset
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .level
-    p {
-    align-self: flex-start;
-    font-size: 1.2em;
-    font-weight: 900;
-    text-transform: uppercase;
-}
-.statblock.basic-pathfinder-2e-layoutset
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .name
-    span.property-name,
-.statblock.basic-pathfinder-2e-layoutset
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .level
-    span.property-name {
-    display: none;
-}
-.statblock.basic-pathfinder-2e-layoutset
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    .image {
-    width: unset;
-    height: unset;
-}
-.statblock.basic-pathfinder-2e-layoutset
-    .statblock-item-inline:has(.statblock-inline-item .name)
-    .statblock-inline-item
-    img {
-    width: unset;
-    height: var(--statblock-property-line-height);
-    border-radius: 0;
-    border: none;
-}
-.statblock.basic-pathfinder-2e-layoutset ul {
-    display: block;
-    list-style-type: var(--statblock-list-style-type);
-    margin-block-start: var(--statblock-list-margin-block-start);
-    margin-block-end: var(--statblock-list-margin-block-end);
-    margin-inline-start: var(--statblock-list-margin-inline-start);
-    margin-inline-end: var(--statblock-list-margin-inline-end);
-    padding-inline-start: var(--statblock-list-padding-inline-start);
-}
-.statblock.basic-pathfinder-2e-layoutset .markdown-rendered ul,
-.statblock.basic-pathfinder-2e-layoutset .markdown-rendered ol {
-    padding-inline-start: var(--statblock-list-indent);
-}
-.statblock.basic-pathfinder-2e-layoutset li {
-    color: var(--statblock-content-font);
-    display: list-item;
-    text-align: var(--statblock-list-text-align);
-}
-.statblock.basic-pathfinder-2e-layoutset .markdown-source-view ol > li,
-.statblock.basic-pathfinder-2e-layoutset .markdown-source-view ul > li,
-.statblock.basic-pathfinder-2e-layoutset .markdown-preview-view ol > li,
-.statblock.basic-pathfinder-2e-layoutset .markdown-preview-view ul > li,
-.statblock.basic-pathfinder-2e-layoutset .markdown-rendered ul > li,
-.statblock.basic-pathfinder-2e-layoutset .mod-cm6 .HyperMD-list-line.cm-line {
-    padding-top: var(--statblock-list-padding-top);
-    padding-bottom: var(--statblock-list-padding-bottom);
-}
-.statblock.basic-pathfinder-2e-layoutset ol > li::marker,
-.statblock.basic-pathfinder-2e-layoutset ul > li::marker,
-.statblock.basic-pathfinder-2e-layoutset .cm-s-obsidian .cm-formatting-list {
-    color: var(--list-marker-color);
-}
-.statblock.basic-pathfinder-2e-layoutset ::marker {
-    unicode-bidi: isolate;
-    font-variant-numeric: tabular-nums;
-    text-transform: none;
-    text-indent: 0;
-    text-align: start;
-    text-align-last: start;
-}
+
+/*# sourceMappingURL=index.css.map */

--- a/src/layouts/pathfinder 2e/pf2e.ts
+++ b/src/layouts/pathfinder 2e/pf2e.ts
@@ -121,416 +121,403 @@ export const StatblockPF2e: StatblockItem[] = [
 export const LayoutPF2e: DefaultLayout = {
     blocks: [
         {
-            type: "inline",
-            id: "e9b8483aeafa",
-            properties: [],
-            nested: [
+            "type": "inline",
+            "id": "e9b8483aeafa",
+            "properties": [],
+            "nested": [
                 {
-                    type: "property",
-                    id: "2b596a6919fb",
-                    properties: ["name"],
-                    fallback: "-",
-                    markdown: true,
-                    dice: false,
-                    conditioned: true,
-                    display: " "
+                    "type": "property",
+                    "id": "2b596a6919fb",
+                    "properties": [
+                        "name"
+                    ],
+                    "fallback": "-",
+                    "markdown": true,
+                    "dice": false,
+                    "conditioned": true,
+                    "display": " "
                 },
                 {
-                    type: "property",
-                    id: "98389a48f808",
-                    properties: ["level"],
-                    fallback: "-",
-                    display: " ",
-                    conditioned: true,
-                    markdown: true,
-                    dice: false
+                    "type": "property",
+                    "id": "98389a48f808",
+                    "properties": [
+                        "level"
+                    ],
+                    "fallback": "-",
+                    "display": " ",
+                    "conditioned": true,
+                    "markdown": true,
+                    "dice": false
                 }
             ],
-            hasRule: false
+            "hasRule": true
         },
         {
-            type: "group",
-            id: "4b3a6809a938",
-            properties: [],
-            nested: [
+            "type": "group",
+            "id": "4b3a6809a938",
+            "properties": [],
+            "nested": [
                 {
-                    type: "inline",
-                    id: "289a4b787968",
-                    properties: [],
-                    nested: [
+                    "type": "inline",
+                    "id": "289a4b787968",
+                    "properties": [],
+                    "nested": [
                         {
-                            type: "inline",
-                            id: "ba68494bf919",
-                            properties: [],
-                            nested: [
-                                {
-                                    type: "property",
-                                    id: "596a89b90ac9",
-                                    properties: ["rare_01"],
-                                    fallback: "-",
-                                    conditioned: true,
-                                    markdown: true,
-                                    dice: false,
-                                    display: "  "
-                                },
-                                {
-                                    type: "property",
-                                    id: "3b591bc93858",
-                                    properties: ["rare_02"],
-                                    fallback: "-",
-                                    conditioned: true,
-                                    markdown: true,
-                                    dice: false,
-                                    display: " "
-                                },
-                                {
-                                    type: "property",
-                                    id: "3bcab8fab86a",
-                                    properties: ["rare_03"],
-                                    fallback: "-",
-                                    conditioned: true,
-                                    display: " ",
-                                    markdown: true,
-                                    dice: false
-                                },
-                                {
-                                    type: "property",
-                                    id: "58e9985a2a69",
-                                    properties: ["rare_04"],
-                                    fallback: "-",
-                                    conditioned: true,
-                                    markdown: true,
-                                    dice: false,
-                                    display: " "
-                                }
-                            ]
+                            "type": "property",
+                            "id": "694a3888b859",
+                            "properties": [
+                                "rare_01"
+                            ],
+                            "fallback": "-",
+                            "conditioned": true,
+                            "markdown": true
                         },
                         {
-                            type: "property",
-                            id: "ba891ba8cbeb",
-                            properties: ["alignment"],
-                            fallback: " ",
-                            display: " ",
-                            conditioned: true,
-                            markdown: true
+                            "type": "property",
+                            "id": "590a88988ae8",
+                            "properties": [
+                                "rare_02"
+                            ],
+                            "fallback": "-",
+                            "conditioned": true,
+                            "markdown": true
                         },
                         {
-                            type: "property",
-                            id: "ebf9883938a8",
-                            properties: ["size"],
-                            fallback: " ",
-                            display: " ",
-                            conditioned: true,
-                            markdown: true
+                            "type": "property",
+                            "id": "9a9be808699a",
+                            "properties": [
+                                "rare_03"
+                            ],
+                            "fallback": "-",
+                            "conditioned": true,
+                            "markdown": true
                         },
                         {
-                            type: "property",
-                            id: "dabaf9e9fb68",
-                            properties: ["trait_01"],
-                            fallback: " ",
-                            display: " ",
-                            conditioned: true,
-                            markdown: true
+                            "type": "property",
+                            "id": "2988db1a685a",
+                            "properties": [
+                                "rare_04"
+                            ],
+                            "fallback": "-",
+                            "conditioned": true,
+                            "markdown": true
                         },
                         {
-                            type: "property",
-                            id: "e81a6aeadbf9",
-                            properties: ["trait_02"],
-                            fallback: " ",
-                            display: " ",
-                            conditioned: true,
-                            markdown: true
+                            "type": "property",
+                            "id": "ba891ba8cbeb",
+                            "properties": [
+                                "alignment"
+                            ],
+                            "fallback": " ",
+                            "display": " ",
+                            "conditioned": true,
+                            "markdown": true
                         },
                         {
-                            type: "property",
-                            id: "fa7919caabbb",
-                            properties: ["trait_03"],
-                            fallback: "-",
-                            conditioned: true,
-                            display: " ",
-                            markdown: true
+                            "type": "property",
+                            "id": "ebf9883938a8",
+                            "properties": [
+                                "size"
+                            ],
+                            "fallback": " ",
+                            "display": " ",
+                            "conditioned": true,
+                            "markdown": true
                         },
                         {
-                            type: "property",
-                            id: "58c9c8580b68",
-                            properties: ["trait_04"],
-                            fallback: "-",
-                            conditioned: true,
-                            display: " ",
-                            markdown: true
+                            "type": "property",
+                            "id": "dabaf9e9fb68",
+                            "properties": [
+                                "trait_01"
+                            ],
+                            "fallback": " ",
+                            "display": " ",
+                            "conditioned": true,
+                            "markdown": true
                         },
                         {
-                            type: "property",
-                            id: "da894a7b8849",
-                            properties: ["trait_05"],
-                            fallback: "-",
-                            display: " ",
-                            conditioned: true,
-                            markdown: true
+                            "type": "property",
+                            "id": "e81a6aeadbf9",
+                            "properties": [
+                                "trait_02"
+                            ],
+                            "fallback": " ",
+                            "display": " ",
+                            "conditioned": true,
+                            "markdown": true
                         },
                         {
-                            type: "property",
-                            id: "fb6b4b6bab49",
-                            properties: ["trait_06"],
-                            fallback: "-",
-                            display: " ",
-                            conditioned: true,
-                            markdown: true
+                            "type": "property",
+                            "id": "fa7919caabbb",
+                            "properties": [
+                                "trait_03"
+                            ],
+                            "fallback": "-",
+                            "conditioned": true,
+                            "display": " ",
+                            "markdown": true
                         },
                         {
-                            type: "property",
-                            id: "480a5bfafb88",
-                            properties: ["trait_07"],
-                            fallback: "-",
-                            display: " ",
-                            conditioned: true,
-                            markdown: true
+                            "type": "property",
+                            "id": "58c9c8580b68",
+                            "properties": [
+                                "trait_04"
+                            ],
+                            "fallback": "-",
+                            "conditioned": true,
+                            "display": " ",
+                            "markdown": true
+                        },
+                        {
+                            "type": "property",
+                            "id": "da894a7b8849",
+                            "properties": [
+                                "trait_05"
+                            ],
+                            "fallback": "-",
+                            "display": " ",
+                            "conditioned": true,
+                            "markdown": true
+                        },
+                        {
+                            "type": "property",
+                            "id": "fb6b4b6bab49",
+                            "properties": [
+                                "trait_06"
+                            ],
+                            "fallback": "-",
+                            "display": " ",
+                            "conditioned": true,
+                            "markdown": true
+                        },
+                        {
+                            "type": "property",
+                            "id": "480a5bfafb88",
+                            "properties": [
+                                "trait_07"
+                            ],
+                            "fallback": "-",
+                            "display": " ",
+                            "conditioned": true,
+                            "markdown": true
                         }
                     ],
-                    hasRule: true,
-                    conditioned: true
+                    "hasRule": true,
+                    "conditioned": true
                 }
             ]
         },
         {
-            type: "group",
-            id: "5999ea79ca3b",
-            properties: [],
-            nested: [
+            "type": "group",
+            "id": "5999ea79ca3b",
+            "properties": [],
+            "nested": [
                 {
-                    type: "traits",
-                    id: "9a9af9fbe959",
-                    properties: ["perception"],
-                    fallback: "-",
-                    heading: " ",
-                    conditioned: true,
-                    dice: true,
-                    markdown: true,
-                    headingProp: true
+                    "type": "traits",
+                    "id": "9a9af9fbe959",
+                    "properties": [
+                        "perception"
+                    ],
+                    "fallback": "-",
+                    "heading": " ",
+                    "conditioned": true,
+                    "dice": true,
+                    "markdown": true,
+                    "headingProp": true
                 },
                 {
-                    type: "property",
-                    id: "ba28f9384918",
-                    properties: ["languages"],
-                    fallback: "-",
-                    display: "Language",
-                    conditioned: true,
-                    markdown: true
+                    "type": "property",
+                    "id": "ba28f9384918",
+                    "properties": [
+                        "languages"
+                    ],
+                    "fallback": "-",
+                    "display": "Language",
+                    "conditioned": true,
+                    "markdown": true
                 },
                 {
-                    type: "traits",
-                    id: "a8f8187b89fb",
-                    properties: ["skills"],
-                    fallback: "-",
-                    markdown: true,
-                    dice: true,
-                    conditioned: true,
-                    heading: " "
+                    "type": "traits",
+                    "id": "a8f8187b89fb",
+                    "properties": [
+                        "skills"
+                    ],
+                    "fallback": "-",
+                    "markdown": true,
+                    "dice": true,
+                    "conditioned": true,
+                    "heading": " "
                 },
                 {
-                    type: "table",
-                    id: "b82b0a1a9969",
-                    properties: ["abilityMods"],
-                    headers: ["Str", "Dex", "Con", "Int", "Wis", "Cha"],
-                    calculate: false,
-                    fallback: "-",
-                    conditioned: true,
-                    dice: true
+                    "type": "table",
+                    "id": "b82b0a1a9969",
+                    "properties": [
+                        "abilityMods"
+                    ],
+                    "headers": [
+                        "Str",
+                        "Dex",
+                        "Con",
+                        "Int",
+                        "Wis",
+                        "Cha"
+                    ],
+                    "calculate": false,
+                    "fallback": "-",
+                    "conditioned": true,
+                    "dice": true
                 },
                 {
-                    type: "traits",
-                    id: "e96ba9d8a80a",
-                    properties: ["abilities_top"],
-                    fallback: "-",
-                    conditioned: true,
-                    dice: true,
-                    markdown: true,
-                    heading: "  ",
-                    hasRule: false
+                    "type": "traits",
+                    "id": "e96ba9d8a80a",
+                    "properties": [
+                        "abilities_top"
+                    ],
+                    "fallback": "-",
+                    "conditioned": true,
+                    "dice": true,
+                    "markdown": true,
+                    "heading": "  ",
+                    "hasRule": false
                 }
             ],
-            hasRule: true
+            "hasRule": true
         },
         {
-            type: "group",
-            id: "faaa08993a98",
-            properties: [],
-            nested: [
+            "type": "group",
+            "id": "faaa08993a98",
+            "properties": [],
+            "nested": [
                 {
-                    type: "traits",
-                    id: "68ca69891bea",
-                    properties: ["armorclass"],
-                    fallback: "-",
-                    heading: "",
-                    conditioned: true,
-                    dice: true,
-                    markdown: true
+                    "type": "traits",
+                    "id": "68ca69891bea",
+                    "properties": [
+                        "armorclass"
+                    ],
+                    "fallback": "-",
+                    "heading": "",
+                    "conditioned": true,
+                    "dice": true,
+                    "markdown": true
                 },
                 {
-                    type: "traits",
-                    id: "9b1998e9a8da",
-                    properties: ["health"],
-                    fallback: "-",
-                    heading: "",
-                    conditioned: true,
-                    dice: true,
-                    markdown: true
+                    "type": "traits",
+                    "id": "9b1998e9a8da",
+                    "properties": [
+                        "health"
+                    ],
+                    "fallback": "-",
+                    "heading": "",
+                    "conditioned": true,
+                    "dice": true,
+                    "markdown": true
                 },
                 {
-                    type: "traits",
-                    id: "ca2bf968987b",
-                    properties: ["abilities_mid"],
-                    fallback: "-",
-                    heading: "",
-                    conditioned: true,
-                    dice: true,
-                    markdown: true,
-                    hasRule: false
+                    "type": "traits",
+                    "id": "ca2bf968987b",
+                    "properties": [
+                        "abilities_mid"
+                    ],
+                    "fallback": "-",
+                    "heading": "",
+                    "conditioned": true,
+                    "dice": true,
+                    "markdown": true,
+                    "hasRule": false
                 }
             ],
-            hasRule: true
+            "hasRule": true
         },
         {
-            type: "group",
-            id: "cbeabaf93b58",
-            properties: [],
-            nested: [
+            "type": "group",
+            "id": "cbeabaf93b58",
+            "properties": [],
+            "nested": [
                 {
-                    type: "property",
-                    id: "0b4809ba0b29",
-                    properties: ["speed"],
-                    fallback: "-",
-                    display: "Speed",
-                    conditioned: true,
-                    markdown: true,
-                    dice: false
+                    "type": "property",
+                    "id": "0b4809ba0b29",
+                    "properties": [
+                        "speed"
+                    ],
+                    "fallback": "-",
+                    "display": "Speed",
+                    "conditioned": true,
+                    "markdown": true,
+                    "dice": false
                 },
                 {
-                    type: "traits",
-                    id: "882bc9aa0898",
-                    properties: ["attacks"],
-                    fallback: "-",
-                    conditioned: true,
-                    dice: true,
-                    markdown: true,
-                    headingProp: false,
-                    heading: ""
+                    "type": "traits",
+                    "id": "882bc9aa0898",
+                    "properties": [
+                        "attacks"
+                    ],
+                    "fallback": "-",
+                    "conditioned": true,
+                    "dice": true,
+                    "markdown": true,
+                    "headingProp": false,
+                    "heading": ""
                 },
                 {
-                    type: "traits",
-                    id: "6919b8996939",
-                    properties: ["spellcasting"],
-                    fallback: "-",
-                    heading: " ",
-                    markdown: true,
-                    dice: true,
-                    conditioned: true
+                    "type": "traits",
+                    "id": "6919b8996939",
+                    "properties": [
+                        "spellcasting"
+                    ],
+                    "fallback": "-",
+                    "heading": " ",
+                    "markdown": true,
+                    "dice": true,
+                    "conditioned": true
                 },
                 {
-                    type: "traits",
-                    id: "aacb399a3b58",
-                    properties: ["abilities_bot"],
-                    fallback: "-",
-                    conditioned: true,
-                    dice: true,
-                    markdown: true,
-                    hasRule: false
+                    "type": "traits",
+                    "id": "aacb399a3b58",
+                    "properties": [
+                        "abilities_bot"
+                    ],
+                    "fallback": "-",
+                    "conditioned": true,
+                    "dice": true,
+                    "markdown": true,
+                    "hasRule": false
                 }
             ],
-            hasRule: true
+            "hasRule": true
         },
         {
-            type: "group",
-            id: "5b2a1888ea7a",
-            properties: [],
-            nested: [
-                {
-                    type: "traits",
-                    id: "b979abb9c8db",
-                    properties: ["spells0"],
-                    fallback: "",
-                    conditioned: true,
-                    markdown: true,
-                    dice: false
-                },
-                {
-                    type: "traits",
-                    id: "5a591889389b",
-                    properties: ["spells1"],
-                    fallback: "-",
-                    hasRule: false,
-                    conditioned: true,
-                    markdown: true,
-                    dice: false
-                },
-                {
-                    type: "traits",
-                    id: "38abd929495b",
-                    properties: ["spells2"],
-                    fallback: "-",
-                    hasRule: false,
-                    markdown: true,
-                    dice: false,
-                    conditioned: true
-                },
-                {
-                    type: "traits",
-                    id: "29590ac9991a",
-                    properties: ["spells3"],
-                    fallback: "-",
-                    markdown: true,
-                    dice: false,
-                    conditioned: true,
-                    hasRule: false
-                },
-                {
-                    type: "traits",
-                    id: "bbdae818fb3a",
-                    properties: ["spells4"],
-                    fallback: "-",
-                    markdown: true,
-                    dice: false,
-                    conditioned: true,
-                    hasRule: false
-                }
-            ]
+            "type": "text",
+            "id": "1b195a894b58",
+            "properties": [
+                "token"
+            ],
+            "text": null,
+            "fallback": "",
+            "heading": "Show to Players",
+            "conditioned": true,
+            "markdown": true
         },
         {
-            type: "group",
-            id: "388b38a988a9",
-            properties: [],
-            nested: [
-                {
-                    type: "inline",
-                    id: "ca39991848aa",
-                    properties: [],
-                    nested: [
-                        {
-                            type: "inline",
-                            id: "d9695a9aebfa",
-                            properties: [],
-                            nested: []
-                        },
-                        {
-                            type: "inline",
-                            id: "99fad9aaea39",
-                            properties: [],
-                            nested: [
-                                {
-                                    type: "property",
-                                    id: "88e97a485b79",
-                                    properties: ["sourcebook"],
-                                    fallback: "-",
-                                    conditioned: true,
-                                    markdown: true,
-                                    dice: false,
-                                    display: " Source:"
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
+            "type": "image",
+            "id": "1bba89582b29",
+            "properties": [
+                "token"
+            ],
+            "fallback": "",
+            "conditioned": true,
+            "hasRule": true
+        },
+        {
+            "type": "property",
+            "id": "88e97a485b79",
+            "properties": [
+                "sourcebook"
+            ],
+            "fallback": "-",
+            "conditioned": true,
+            "markdown": true,
+            "dice": false,
+            "display": " Source:"
         }
     ],
     name: "Basic Pathfinder 2e Layout",


### PR DESCRIPTION
1. Removed unnecessary boxes in layout preparation for layout overhaul in 1.6. Rendering should be slightly faster.
2. Added "token" YAML key for images. token will automatically reverse the image and be located near the end of the statblock.
3. Added attached text block for token YAML key, so Image Window can be used with the image links. 
4. Added more static items to in-file sass variables to reduce the amount of items needed in dash variables.
5. Fixed popovers with blocklinks.
6. Snippet size is now at ~3450 lines.

I included the regular Layout export.. just in case I messed up the pf2e.ts merge as its my first time doing it. :)