### PR TITLE
Upgrade xmldom to v0.7.10, fixing two security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
                 "@types/dom-to-image": "^2.6.2",
                 "@types/node": "^14.17.21",
                 "@types/xmldom": "^0.1.31",
+                "@xmldom/xmldom": "^0.7.10",
                 "babel-loader": "^8.2.3",
                 "builtins": "^4.0.0",
                 "copy-webpack-plugin": "^10.0.0",
@@ -60,8 +61,7 @@
                 "typescript": "^4.0.3",
                 "webpack": "^5.64.1",
                 "webpack-cli": "^4.9.1",
-                "worker-loader": "^3.0.8",
-                "xmldom": "^0.6.0"
+                "worker-loader": "^3.0.8"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -2326,6 +2326,15 @@
                 "webpack-dev-server": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@xmldom/xmldom": {
+            "version": "0.7.10",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.10.tgz",
+            "integrity": "sha512-hb9QhOg5MGmpVkFcoZ9XJMe1em5gd0e2eqqjK87O1dwULedXsnY/Zg/Ju6lcohA+t6jVkmKpe7I1etqhvdRdrQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=10.0.0"
             }
         },
         "node_modules/@xtuc/ieee754": {
@@ -10436,15 +10445,6 @@
             "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
             "dev": true
         },
-        "node_modules/xmldom": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-            "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==",
-            "dev": true,
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
         "node_modules/xtend": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -12221,6 +12221,12 @@
             "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
             "dev": true,
             "requires": {}
+        },
+        "@xmldom/xmldom": {
+            "version": "0.7.10",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.10.tgz",
+            "integrity": "sha512-hb9QhOg5MGmpVkFcoZ9XJMe1em5gd0e2eqqjK87O1dwULedXsnY/Zg/Ju6lcohA+t6jVkmKpe7I1etqhvdRdrQ==",
+            "dev": true
         },
         "@xtuc/ieee754": {
             "version": "1.2.0",
@@ -18124,12 +18130,6 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
             "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-            "dev": true
-        },
-        "xmldom": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-            "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==",
             "dev": true
         },
         "xtend": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "@types/dom-to-image": "^2.6.2",
         "@types/node": "^14.17.21",
         "@types/xmldom": "^0.1.31",
+        "@xmldom/xmldom": "^0.7.10",
         "babel-loader": "^8.2.3",
         "builtins": "^4.0.0",
         "copy-webpack-plugin": "^10.0.0",
@@ -65,8 +66,7 @@
         "typescript": "^4.0.3",
         "webpack": "^5.64.1",
         "webpack-cli": "^4.9.1",
-        "worker-loader": "^3.0.8",
-        "xmldom": "^0.6.0"
+        "worker-loader": "^3.0.8"
     },
     "dependencies": {
         "yaml": "^2.1.3"

--- a/src/importers/DnDAppFilesImport.ts
+++ b/src/importers/DnDAppFilesImport.ts
@@ -1,5 +1,5 @@
 import type { Monster, Spell, Trait } from "@types";
-import { DOMParser } from "xmldom";
+import { DOMParser } from "@xmldom/xmldom";
 
 export async function buildMonsterFromAppFile(file: File): Promise<Monster[]> {
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
Currently, `fantasy-statblocks` has a [direct dependency](https://github.com/valentine195/fantasy-statblocks/blob/master/package-lock.json#L10439) on v0.6.0 of the `xmldom` package.

This is a problem because this package contains two known, notable security vulnerabilities:

* [Critical severity – xmldom allows multiple root nodes in a DOM](https://github.com/advisories/GHSA-crh6-fp67-6883)
* [Moderate severity – Misinterpretation of malicious XML input](https://github.com/advisories/GHSA-5fg8-2547-mr8q)

This is also a problem because, as of v0.7.0, [this package](https://www.npmjs.com/package/@xmldom/xmldom) is published to npm as `@xmldom/xmldom` and no longer as `xmldom`. According to the package's maintainers, they are [no longer able to publish](https://www.npmjs.com/package/xmldom?activeTab=versions) `xmldom` to npm as an unscoped package.

As a new contributor, I'd like to help `fantasy-statblocks` migrate to v0.7.10—the latest version of the v0.7.x codebase that that [does not contain](https://github.com/xmldom/xmldom/blob/master/CHANGELOG.md#070) breaking changes. NOTE: The v0.8.x codebase [does contain](https://github.com/xmldom/xmldom/blob/master/CHANGELOG.md#080) breaking changes, and may require a bit more testing to ensure compatibility with `fantasy-statblocks`.
